### PR TITLE
Only require QUnit during tests

### DIFF
--- a/shared/gh/api/gh.api.js
+++ b/shared/gh/api/gh.api.js
@@ -16,8 +16,8 @@
 /**
  * Initialises the grasshopper APIs
  */
-define(['gh.api.admin', 'gh.api.app', 'gh.api.authentication', 'gh.api.config', 'gh.api.event', 'gh.api.orgunit', 'gh.api.series', 'gh.api.tenant', 'gh.api.tests', 'gh.api.user', 'gh.api.util'],
-    function(adminAPI, appAPI, authenticationAPI, configAPI, eventAPI, orgunitAPI, seriesAPI, tenantAPI, testsAPI, userAPI, utilAPI) {
+define(['gh.api.admin', 'gh.api.app', 'gh.api.authentication', 'gh.api.config', 'gh.api.event', 'gh.api.orgunit', 'gh.api.series', 'gh.api.tenant', 'gh.api.user', 'gh.api.util'],
+    function(adminAPI, appAPI, authenticationAPI, configAPI, eventAPI, orgunitAPI, seriesAPI, tenantAPI, userAPI, utilAPI) {
 
         var gh = {
             'api': {
@@ -29,7 +29,6 @@ define(['gh.api.admin', 'gh.api.app', 'gh.api.authentication', 'gh.api.config', 
                 'orgunitAPI': orgunitAPI,
                 'seriesAPI': seriesAPI,
                 'tenantAPI': tenantAPI,
-                'testsAPI': testsAPI,
                 'userAPI': userAPI,
                 'utilAPI': utilAPI
             }

--- a/shared/gh/api/gh.api.tests.js
+++ b/shared/gh/api/gh.api.tests.js
@@ -25,6 +25,14 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.tenant'], func
     ////////////////////////
 
     /**
+     * Initialise the QUnit async tests
+     */
+    var init = exports.init = function() {
+        QUnit.moduleStart(onModuleStart);
+        QUnit.start();
+    };
+
+    /**
      * Return an app by its id
      *
      * @param  {Number}    appId    The application id
@@ -99,13 +107,6 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.tenant'], func
     //////////////////////////
     //  INTERNAL FUNCTIONS  //
     //////////////////////////
-
-    /**
-     * Initialise the QUnit async tests
-     */
-    var init = function() {
-        QUnit.moduleStart(onModuleStart);
-    };
 
     /**
      * Function that is executed before the QUnit module test is started
@@ -202,7 +203,4 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.tenant'], func
         // Start fetching the apps
         _fetchAppsForTenant();
     };
-
-    // Initialise the tests
-    init();
 });

--- a/tests/qunit/tests/js/api.admin.js
+++ b/tests/qunit/tests/js/api.admin.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     QUnit.module('Admin API');
 
     /*!
@@ -157,5 +157,5 @@ require(['gh.core'], function(gh) {
         });
     });
 
-    QUnit.start();
+    testAPI.init();
 });

--- a/tests/qunit/tests/js/api.app.js
+++ b/tests/qunit/tests/js/api.app.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     module('App API');
 
     // Test the getApps functionality
@@ -21,7 +21,7 @@ require(['gh.core'], function(gh) {
         expect(5);
 
         // Fetch a random test tenant
-        var tenant = gh.api.testsAPI.getRandomTenant();
+        var tenant = testAPI.getRandomTenant();
 
         // Verify that an error is thrown when an invalid tenantId was provided
         gh.api.appAPI.getApps(null, function(err, data) {
@@ -45,5 +45,5 @@ require(['gh.core'], function(gh) {
         });
     });
 
-    QUnit.start();
+    testAPI.init();
 });

--- a/tests/qunit/tests/js/api.authentication.js
+++ b/tests/qunit/tests/js/api.authentication.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     module('Authentication API');
 
     /*!
@@ -32,7 +32,7 @@ require(['gh.core'], function(gh) {
                 return callback(err);
             }
 
-            var appId = gh.api.testsAPI.getRandomApp().id;
+            var appId = testAPI.getRandomApp().id;
             var displayName = gh.api.utilAPI.generateRandomString();
             var email = gh.api.utilAPI.generateRandomString();
             var password = gh.api.utilAPI.generateRandomString();
@@ -87,5 +87,5 @@ require(['gh.core'], function(gh) {
         });
     });
 
-    QUnit.start();
+    testAPI.init();
 });

--- a/tests/qunit/tests/js/api.config.js
+++ b/tests/qunit/tests/js/api.config.js
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     module('Config API');
 
     QUnit.test('init', function(assert) {
         assert.ok(true);
     });
 
-    QUnit.start();
+    testAPI.init();
 });

--- a/tests/qunit/tests/js/api.event.js
+++ b/tests/qunit/tests/js/api.event.js
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     module('Event API');
 
     QUnit.test('init', function(assert) {
         assert.ok(true);
     });
 
-    QUnit.start();
+    testAPI.init();
 });

--- a/tests/qunit/tests/js/api.orgunit.js
+++ b/tests/qunit/tests/js/api.orgunit.js
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     module('Orgunit API');
 
     QUnit.test('init', function(assert) {
         assert.ok(true);
     });
 
-    QUnit.start();
+    testAPI.init();
 });

--- a/tests/qunit/tests/js/api.series.js
+++ b/tests/qunit/tests/js/api.series.js
@@ -13,12 +13,12 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     module('Series API');
 
     QUnit.test('init', function(assert) {
         assert.ok(true);
     });
 
-    QUnit.start();
+    testAPI.init();
 });

--- a/tests/qunit/tests/js/api.tenant.js
+++ b/tests/qunit/tests/js/api.tenant.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     module('Tenant API');
 
     // Test the getTenants functionality
@@ -36,5 +36,5 @@ require(['gh.core'], function(gh) {
         }
     });
 
-    QUnit.start();
+    testAPI.init();
 });

--- a/tests/qunit/tests/js/api.user.js
+++ b/tests/qunit/tests/js/api.user.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core'], function(gh) {
+require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     QUnit.module('User API');
 
     /*!
@@ -32,7 +32,7 @@ require(['gh.core'], function(gh) {
                 return callback(err);
             }
 
-            var appId = gh.api.testsAPI.getRandomApp().id;
+            var appId = testAPI.getRandomApp().id;
             var user = {
                 'displayName': gh.api.utilAPI.generateRandomString(),
                 'email': gh.api.utilAPI.generateRandomString(),
@@ -381,7 +381,7 @@ require(['gh.core'], function(gh) {
     QUnit.asyncTest('createUser', function(assert) {
         expect(7);
 
-        var appId = gh.api.testsAPI.getRandomApp().id;
+        var appId = testAPI.getRandomApp().id;
         var user = {
             'displayName': gh.api.utilAPI.generateRandomString(),
             'email': gh.api.utilAPI.generateRandomString(),
@@ -429,7 +429,7 @@ require(['gh.core'], function(gh) {
         expect(8);
 
         // Get a random tenant id
-        var tenantId = gh.api.testsAPI.getRandomTenant().id;
+        var tenantId = testAPI.getRandomTenant().id;
 
         // Create a new user
         _generateRandomUser(function(err, user) {
@@ -655,5 +655,5 @@ require(['gh.core'], function(gh) {
         });
     });
 
-    QUnit.start();
+    testAPI.init();
 });


### PR DESCRIPTION
QUnit should only be required when tests are run using Grunt.
