### PR TITLE
Fit calendar height to its parent's height

### DIFF
--- a/shared/gh/js/bootstrap.calendar.js
+++ b/shared/gh/js/bootstrap.calendar.js
@@ -431,7 +431,7 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
             'handleWindowResize': false,
             'maxTime': '20:00:00',
             'minTime': '07:00:00',
-            'slotDuration': '00:15:00',
+            'slotDuration': '00:30:00',
             'events': events,
             'eventRender': function(data) {
                 return gh.api.utilAPI.renderTemplate($('#gh-event-template'), {


### PR DESCRIPTION
The height of the calendar should be set to its parent's height. This should allow us to have a resizable calendar without scrollbars. Since this probably won't be working by using CSS only, we should opt for a JS solution. (@see [article](http://stackoverflow.com/questions/13862942/how-to-make-jquery-fullcalendars-height-fit-its-content)).
