### PR TITLE
Moment.js deprecation warning

### DIFF
--- a/shared/gh/api/gh.api.util.js
+++ b/shared/gh/api/gh.api.util.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['exports', 'moment'], function(exports) {
+define(['exports', 'moment'], function(exports, moment) {
 
     /**
      * Add support for partials in Lodash. `_.mixin` allows us to extend underscore with

--- a/shared/gh/js/bootstrap.calendar.js
+++ b/shared/gh/js/bootstrap.calendar.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'clickover', 'moment'], function(gh) {
+define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
 
 
     ////////////////


### PR DESCRIPTION
Currently we're having a deprecation warning when using Moment.js.

`Deprecation warning: Accessing Moment through the global scope is deprecated, and will be removed in an upcoming release.`
