### PR TITLE
Fix padding in today box in month view

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -135,7 +135,7 @@
 .gh-toolbar-label {
     display: inline-block;
     text-align: center;
-    width: 100px;
+    min-width: 100px;
 }
 
 /* Calendar (assumes weekly view and other views inherit unless otherwise specified) */
@@ -190,13 +190,18 @@
     position: absolute;
 }
 
+.fc-ltr .fc-basic-view .fc-day-number,
+.fc-ltr .fc-basic-view .fc-today.fc-day-number {
+    padding: 8px 8px 8px 11px;
+}
+
 .fc-ltr .fc-basic-view .fc-day-number {
-    padding: 5px;
     text-align: left;
 }
 
 .fc-ltr .fc-basic-view .fc-today.fc-day-number {
-    padding: 2px 5px 5px 5px;
+    font-weight: bold;
+    padding-top: 5px;
 }
 
 .fc-slats .fc-minor td {


### PR DESCRIPTION
It looks like a specific padding is applied on the current day in the month view, what causes the number to be positioned higher than the other numbers. The font weight of the day number should also be increased to be analog with the designs.

![screen shot 2014-12-02 at 16 20 45](https://cloud.githubusercontent.com/assets/2194396/5266065/37902a0a-7a3f-11e4-83e8-6335e179ce7f.png)
