### PR TITLE
Fix borders of the calendar in Firefox + Safari

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -158,12 +158,8 @@
     font-weight: 600;
 }
 
-.fc table {
-    border-collapse: inherit;
-}
-
-.fc-month-view .fc-week table {
-    border-collapse: collapse;
+#gh-calendar-container .fc-widget-header .fc-row > table {
+    border-collapse: initial;
 }
 
 .fc-row.fc-widget-header thead tr th,


### PR DESCRIPTION
For some reason the calendar's border aren't showing up properly in Firefox and Safari.
