### PR TITLE
Improve code coverage in non-api modules

### DIFF
--- a/shared/gh/api/gh.api.event.js
+++ b/shared/gh/api/gh.api.event.js
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
+/* istanbul ignore next */
 define(['exports'], function(exports) {
 
     /**

--- a/shared/gh/api/gh.api.js
+++ b/shared/gh/api/gh.api.js
@@ -41,6 +41,7 @@ define(['gh.api.admin', 'gh.api.app', 'gh.api.authentication', 'gh.api.config', 
         var initGH = function(callback) {
             // Load the me feed
             userAPI.getMe(function(err, me) {
+                /* istanbul ignore if */
                 if (!err) {
                     gh.data.me = me;
                 } else {

--- a/shared/gh/api/gh.api.tests.js
+++ b/shared/gh/api/gh.api.tests.js
@@ -41,16 +41,6 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.orgunit', 'gh.
     };
 
     /**
-     * Return an app by its id
-     *
-     * @param  {Number}    appId    The application id
-     * @return {Object}             Object representing an application
-     */
-    var getAppById = exports.getAppById = function(appId) {
-        return _.find(_apps, {'id': appId});
-    };
-
-    /**
      * Return the test apps
      *
      * @return {Object[]}    The test apps
@@ -112,37 +102,6 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.orgunit', 'gh.
     };
 
     /**
-     * Return a tenant and its applications by its id
-     *
-     * @param  {Number}    tenantId    The tenant id
-     * @return {Object}                Object representing a tenant
-     */
-    var getTenantById = exports.getTenantById = function(tenantId) {
-        var tenants = _.cloneDeep(_tenants);
-        return _.find(tenants, function(tenant) {
-
-            // Add the tenant's applications
-            if (tenant.id === tenantId) {
-                return _.extend(tenant, {'apps': _.filter(_apps, {'TenantId': tenant.id})});
-            }
-        });
-    };
-
-    /**
-     * Return the test tenants
-     *
-     * @return {Object[]}    The test tenants
-     */
-    var getTenants = exports.getTenants = function() {
-        var tenants = _.cloneDeep(_tenants);
-        return _.map(tenants, function(tenant) {
-
-            // Add the tenants' applications
-            return _.extend(tenant, {'apps': _.filter(_apps, {'TenantId': tenant.id})});
-        });
-    };
-
-    /**
      * Returns the test application types
      */
     var getTypes = exports.getTypes = function() {
@@ -157,16 +116,13 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.orgunit', 'gh.
     /**
      * Fetches all the tenants
      *
-     * @param  {Function}    [callback]    Standard callback function
+     * @param  {Function}    callback    Standard callback function
      * @private
      */
     var fetchTenants = function(callback) {
-
-        // Set a default callback function in case no callback function has been provided
-        callback = callback || function() {};
-
         // Fetch all the tenants
         tenantAPI.getTenants(function(err, tenants) {
+            /* istanbul ignore if */
             if (err) {
                 QUnit.stop();
             }
@@ -181,14 +137,10 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.orgunit', 'gh.
     /**
      * Fetch all the applications for the tenants
      *
-     * @param  {Function}    [callback]    Standard callback function
+     * @param  {Function}    callback    Standard callback function
      * @private
      */
     var fetchAppsForTenants = function(callback) {
-
-        // Set a default callback function in case no callback function has been provided
-        callback = callback || function() {};
-
         // Collect the tenantIds
         var tenantIds = _.map(_tenants, function(tenant) { return tenant.id; });
 
@@ -204,6 +156,7 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.orgunit', 'gh.
 
             // Fetch the apps for the tenant
             appAPI.getApps(tenantId, function(err, apps) {
+                /* istanbul ignore if */
                 if (err) {
                     return QUnit.stop();
                 }
@@ -225,10 +178,12 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.orgunit', 'gh.
         _fetchAppsForTenant();
     };
 
+    /**
+     * Fetch all organisational units for tenants
+     *
+     * @param  {Function}    callback    Standard callback function
+     */
     var fetchOrgUnitsForTenants = function(callback) {
-        // Set a default callback function in case no callback function has been provided
-        callback = callback || function() {};
-
         // Collect the appIds
         var appIds = _.map(_apps, function(app) { return app.id; });
 
@@ -244,6 +199,7 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.orgunit', 'gh.
 
             // Fetch the orgunits for the app
             orgunitAPI.getOrgUnits(appId, true, null, null, function(err, orgunits) {
+                /* istanbul ignore if */
                 if (err) {
                     return QUnit.stop();
                 }
@@ -304,6 +260,7 @@ define(['exports', 'gh.api.app', 'gh.api.authentication', 'gh.api.orgunit', 'gh.
 
         // Login with the global administrator
         authenticationAPI.login('administrator', 'administrator', function(err, data) {
+            /* istanbul ignore if */
             if (err) {
                 QUnit.stop();
             }

--- a/shared/gh/api/gh.bootstrap.js
+++ b/shared/gh/api/gh.bootstrap.js
@@ -71,8 +71,10 @@ require(['gh.core'], function() {
     // Find the script that has specified both the data-main (which loaded this bootstrap script) and a data-loadmodule attribute. The
     // data-loadmodule attribute tells us which script they wish to load *after* the core APIs have been properly bootstrapped.
     var $mainScript = $('script[data-main][data-loadmodule]');
+    /* istanbul ignore else */
     if ($mainScript.length > 0) {
         var loadModule = $mainScript.attr('data-loadmodule');
+        /* istanbul ignore else */
         if (loadModule) {
             // Require the module they specified in the data-loadmodule attribute
             require([loadModule]);

--- a/tests/qunit/tests/js/api.user.js
+++ b/tests/qunit/tests/js/api.user.js
@@ -138,7 +138,7 @@ require(['gh.core', 'gh.api.tests', 'sinon'], function(gh, testAPI, sinon) {
 
     // Test the getMe functionality
     QUnit.asyncTest('getMe', function(assert) {
-        expect(2);
+        expect(5);
 
         // Create a new user
         _generateRandomUser(function(err, user) {
@@ -149,17 +149,24 @@ require(['gh.core', 'gh.api.tests', 'sinon'], function(gh, testAPI, sinon) {
                 gh.api.userAPI.getMe();
             }, 'Verify that an error is thrown when an invalid callback was provided');
 
-            // Verify that users can be retrieved without errors
-            gh.api.userAPI.getMe(function(err, data) {
+            // Verify that the me feed can be successfully retrieved
+            // TODO: Switch this mocked call out with the proper API request once it has been implemented in the backend
+            var body = {'code': 200, 'msg': 'OK'};
+            gh.api.utilAPI.mockRequest('GET', '/api/me', 200, {'Content-Type': 'application/json'}, body, function() {
+                gh.api.userAPI.getMe(function(err, data) {
+                    assert.ok(!err, 'Verify that the me feed can be successfully retrieved');
 
-                /**
-                 * TODO: wait for back-end implementation
-                 *
-                assert.ok(!err, 'Verify that the current can be retrieved without errors');
-                assert.ok(data, 'Verify that the current user is returned');
-                 */
+                    // Verify that the error is handled when the calendar can't be retrieved
+                    body = {'code': 400, 'msg': 'Bad Request'};
+                    gh.api.utilAPI.mockRequest('GET', '/api/me', 400, {'Content-Type': 'application/json'}, body, function() {
+                        gh.api.userAPI.getMe(function(err, data) {
+                            assert.ok(err, 'Verify that the error is handled when the me feed can\'t be successfully retrieved');
+                            assert.ok(!data, 'Verify that no data returns when the me feed can\'t be successfully retrieved');
 
-                QUnit.start();
+                            QUnit.start();
+                        });
+                    });
+                });
             });
         });
     });

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -261,21 +261,24 @@ require(['gh.core', 'gh.api.tests', 'sinon'], function(gh, testAPI, sinon) {
     //  TEMPLATES  //
     /////////////////
 
-    // Add a template to the page
-    $('body').append('<script id="qunit-template" type="text/template">Hi, <%= name %></script>');
-    // Create the data to use in the template
-    var templateData = {
-        'name': 'Mathieu'
-    };
-    // Add a target container to the page
-    $('body').append('<div id="qunit-template-target" style="display: none;"></div>');
-
     // Test the 'renderTemplate' functionality
     QUnit.test('renderTemplate', function(assert) {
+        // Add a template to the page
+        $('body').append('<script id="qunit-template" type="text/template">Hi, <%= name %></script>');
+        // Create the data to use in the template
+        var templateData = {
+            'name': 'Mathieu'
+        };
+        // Add a target container to the page
+        $('body').append('<div id="qunit-template-target" style="display: none;"></div>');
+
         // Verify that a template needs to be provided
         assert.throws(function() {
             gh.api.utilAPI.renderTemplate(null, templateData, $('#qunit-template-target'));
         }, 'Verify that a template needs to be provided');
+
+        // Verify that template data is optional
+        assert.ok(gh.api.utilAPI.renderTemplate($('#qunit-template'), null, $('#qunit-template-target')), 'Verify that template data is optional');
 
         // Verify that the template renders in the target container
         gh.api.utilAPI.renderTemplate($('#qunit-template'), templateData, $('#qunit-template-target'));
@@ -284,6 +287,21 @@ require(['gh.core', 'gh.api.tests', 'sinon'], function(gh, testAPI, sinon) {
         // Verify that the rendered HTML is returned when no target is specified
         var returnedHTML = gh.api.utilAPI.renderTemplate($('#qunit-template'), templateData);
         assert.equal(returnedHTML, 'Hi, Mathieu', 'Verify the rendered HTML returns when no target container is specified');
+    });
+
+    QUnit.test('renderTemplate - Partials', function(assert) {
+        // Verify that a partial can be used to render a template
+        // Add a template to the page
+        $('body').append('<script id="qunit-template-partial" type="text/template"><%= _.partial(\'calendar\', {\'data\': data}) %></script>');
+        // Create the data to use in the template
+        var data = {
+            'data': null
+        };
+        // Add a target container to the page
+        $('body').append('<div id="qunit-template-partial-target" style="display: none;"></div>');
+        // Verify that the template renders in the target container
+        gh.api.utilAPI.renderTemplate($('#qunit-template-partial'), data, $('#qunit-template-partial-target'));
+        assert.ok($('#qunit-template-partial-target').html(), 'Verify the template partial HTML is rendered in the target container');
     });
 
     testAPI.init();


### PR DESCRIPTION
We can still improve the code coverage by adding tests for the non-api modules:
- gh.api
- gh.api.tests
- gh.bootstrap
