### PR TITLE
Limit the amount of notifications that can be generated at once

### DIFF
--- a/shared/gh/api/gh.api.util.js
+++ b/shared/gh/api/gh.api.util.js
@@ -170,12 +170,17 @@ define(['exports', 'moment', 'sinon', 'bootstrap-notify'], function(exports, mom
      * @param  {String}    [title]    The notification title
      * @param  {String}    message    The notification message that will be shown underneath the title
      * @param  {String}    [type]     The notification type. The supported types are `success`, `error` and `info`, as defined in http://getbootstrap.com/components/#alerts. By default, the `success` type will be used
+     * @param  {String}    [id]       Unique identifier for the notification, in case a notification can be triggered twice due to some reason. If a second notification with the same id is triggered it will be ignored
      * @throws {Error}                Error thrown when no message has been provided
      * @return {Boolean}              Returns true when the notification has been shown
      */
-    var notification = exports.notification = function(title, message, type) {
+    var notification = exports.notification = function(title, message, type, id) {
         if (!message) {
             throw new Error('A valid notification message should be provided');
+        }
+
+        if (id && $('#' + id).length) {
+            return false;
         }
 
         // Check if the notifications container has already been created.
@@ -189,7 +194,7 @@ define(['exports', 'moment', 'sinon', 'bootstrap-notify'], function(exports, mom
 
         // If a title has been provided, we wrap it in an h4 and prepend it to the message
         if (title) {
-            message = '<h4>' + title + '</h4>' + message;
+            message = '<h4 id="' + id + '">' + title + '</h4>' + message;
         }
 
         // Show the actual notification

--- a/shared/gh/js/bootstrap.listview.js
+++ b/shared/gh/js/bootstrap.listview.js
@@ -46,7 +46,7 @@ define(['gh.core'], function(gh) {
             // }
 
             // Show a success notification
-            gh.api.utilAPI.notification('Events added.', 'All events where successfully added to your calendar.');
+            gh.api.utilAPI.notification('Events added.', 'All events where successfully added to your calendar.', 'success', 'notification-events-added');
 
             // Add `gh-list-group-item-added` to the list item
             $list.addClass('gh-list-group-item-added');
@@ -80,7 +80,7 @@ define(['gh.core'], function(gh) {
             // }
 
             // Show a success notification
-            gh.api.utilAPI.notification('Events removed.', 'The events were successfully removed from your calendar.');
+            gh.api.utilAPI.notification('Events removed.', 'The events were successfully removed from your calendar.', 'success', 'notification-events-removed');
 
             // Remove `gh-list-group-item-added` from the list item
             $list.removeClass('gh-list-group-item-added');
@@ -114,7 +114,7 @@ define(['gh.core'], function(gh) {
             // }
 
             // Show a success notification
-            gh.api.utilAPI.notification('Events added.', 'All events where successfully added to your calendar.');
+            gh.api.utilAPI.notification('Events added.', 'All events where successfully added to your calendar.', 'success', 'notification-events-added');
 
             // Toggle the event's item-added class
             $this.closest('li').toggleClass('gh-list-group-item-added');
@@ -156,7 +156,7 @@ define(['gh.core'], function(gh) {
             // }
 
             // Show a success notification
-            gh.api.utilAPI.notification('Event removed.', 'The event was successfully removed from your calendar.');
+            gh.api.utilAPI.notification('Event removed.', 'The event was successfully removed from your calendar.', 'success', 'notification-events-removed');
 
             // Toggle the event's item-added class
             $this.closest('li').toggleClass('gh-list-group-item-added');

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -254,6 +254,15 @@ require(['gh.core', 'gh.api.tests', 'sinon'], function(gh, testAPI, sinon) {
 
         // Verify that a notification can be triggered with a title and a message
         assert.ok(gh.api.utilAPI.notification('Notification title', 'Notification message'), 'Verify that a notification can be triggered with a title and a message');
+
+        // Verify that a notification can be triggered with a title, a message and an ID
+        assert.ok(gh.api.utilAPI.notification('Notification title', 'Notification message', 'info', 'test-message'), 'Verify that a notification can be triggered with a title, a message and an ID');
+
+        // Verify that a notification with the same ID can't be triggered
+        assert.ok(!gh.api.utilAPI.notification('Notification title', 'Notification message', 'info', 'test-message'), 'Verify that a notification with the same ID can\'t be triggered');
+
+        // Verify that a notification with the same ID won't be shown twice
+        assert.ok($('#test-message').length === 1, 'Verify that a notification with the same ID won\'t be shown twice');
     });
 
 


### PR DESCRIPTION
Currently, when adding 5 event series to the calendar the user will get 5 notifications. We should limit the amount of similar notifications the user gets.
