### PR TITLE
Intermediate state issue

### DIFF
--- a/shared/gh/partials/list-group-item.html
+++ b/shared/gh/partials/list-group-item.html
@@ -1,13 +1,12 @@
 <% isChild = (typeof isChild === 'undefined') ? false : isChild; %>
 
 <% _.each(data, function(d) { %>
-    <% var subscribedAll = true; %>
+    <% var subscribedAll = false; %>
+    <% var subscribedSome = false; %>
     <% if (!isChild && d.Series) { %>
-        <% _.each(d.Series, function(ev) { %>
-            <% if (!ev.subscribed) { %>
-                <% subscribedAll = false; %>
-            <% } %>
-        <% }); %>
+        <% var numSubscribed = _.size(_.filter(d.Series, {'subscribed': true})); %>
+        <% subscribedAll = (numSubscribed === d.Series.length) %>
+        <% subscribedSome = (numSubscribed && numSubscribed < d.Series.length) %>
     <% } %>
     <li class="list-group-item <% if (d.subscribed || (!isChild && subscribedAll)) { %> gh-list-group-item-added <% } %>" data-id="<%= d.id %>">
         <div class="gh-list-group-item-container">
@@ -39,7 +38,11 @@
                     </button>
                 <% } else { %>
                     <button class="btn btn-link <% if (isChild) { %> gh-add-to-calendar <% } else { %> gh-add-all-to-calendar <% } %>">
+                        <% if (!isChild && subscribedSome) { %>
+                        <i class="fa fa-minus"></i>
+                        <% } else { %>
                         <i class="fa fa-plus"></i>
+                        <% } %>
                     </button>
                 <% } %>
             </div>


### PR DESCRIPTION
When an intermediate state is set on one of the lists in the sidebar and the page is refreshed, that intermediate state should still be shown. Instead the `+` button is back. Assigning to @Coenego who did the initial fix.

![screen shot 2014-12-10 at 16 48 44](https://cloud.githubusercontent.com/assets/218391/5379950/6d82c1ce-808c-11e4-91a9-b172a0425e00.png)
