### PR TITLE
Fix month print view

### DIFF
--- a/shared/gh/css/gh.print.css
+++ b/shared/gh/css/gh.print.css
@@ -23,3 +23,12 @@
     border: 1px solid #127077;
     border-left-width: 5px;
 }
+
+/* Make sure month view prints a full page */
+.fc-day-grid-container {
+    height: 800px !important;
+}
+
+.fc-basic-view tbody .fc-row {
+    height: 9em !important;
+}


### PR DESCRIPTION
Something weird is going on when attempting to print the month view. It looks like the view is being vertically scaled...

![screen shot 2014-12-12 at 12 23 57](https://cloud.githubusercontent.com/assets/2194396/5411571/de5e9f58-81f9-11e4-9c32-d35bb45afc16.png)
