### PR TITLE
Add more meta data to the sidebar items

### DIFF
--- a/shared/gh/partials/list-group-item.html
+++ b/shared/gh/partials/list-group-item.html
@@ -17,15 +17,15 @@
                     </div>
             <% } %>
                     <div class="gh-list-description">
+                        <p><%- d.displayName %></p>
                         <% if (isChild) { %>
-                            <p><%- d.displayName %></p>
-                            <p><%- d.notes %></p>
-                            <p><%- d.location %></p>
-                            <% if (d.organisers && d.organisers.length) { %>
-                                <p><%- d.organisers.toString() %></p>
+                            <p><%- d.metadata.pattern %></p>
+                            <% if (d.metadata.locations && d.metadata.locations.length) { %>
+                                <p><%- d.metadata.locations.join(', ') %></p>
                             <% } %>
-                        <% } else { %>
-                            <p><%- d.displayName %></p>
+                            <% if (d.metadata.organisers && d.metadata.organisers.length) { %>
+                                <p><%- d.metadata.organisers.join(', ') %></p>
+                            <% } %>
                         <% } %>
                     </div>
             <% if (!isChild) { %>


### PR DESCRIPTION
Currently, a slimmed down version of the data specified in the designs is implemented. Bring the sidebar up to par.

![screen shot 2014-12-10 at 11 00 27](https://cloud.githubusercontent.com/assets/218391/5374873/d7d8f27c-805b-11e4-8b66-8fd8e2fa78e5.png)
