### PR TITLE
When logged out, the user's calendar shouldn't be fetched

### DIFF
--- a/apps/timetable/ui/js/index.js
+++ b/apps/timetable/ui/js/index.js
@@ -61,7 +61,7 @@ define(['gh.core', 'bootstrap.calendar', 'bootstrap.listview', 'chosen', 'jquery
             'data': null
         }, $('#gh-main'));
 
-        if (!gh.data.me) {
+        if (gh.data.me.anon) {
             $(document).trigger('gh.calendar.init');
         } else {
             var range = gh.api.utilAPI.getCalendarDateRange();


### PR DESCRIPTION
Currently the user's calendar gets fetched even when visiting the pages as an anonymous user. We shouldn't make the request when the user hasn't logged in yet to avoid showing the error notification.