### PR TITLE
Localstorage issue with modules

### DIFF
--- a/apps/timetable/ui/js/index.js
+++ b/apps/timetable/ui/js/index.js
@@ -133,7 +133,11 @@ define(['gh.core', 'bootstrap.calendar', 'bootstrap.student-listview', 'chosen',
             gh.api.utilAPI.localDataStorage().remove('collapsed');
 
             // Add the current collapsed module(s) back to the local storage
-            collapsedIds = _.compact([$('.gh-list-group-item-open').attr('data-id')]);
+            collapsedIds = $('.gh-list-group-item-open').map(function(index, value) {
+                return $(value).attr('data-id');
+            });
+
+            collapsedIds = _.map(collapsedIds, function(id) { return id; });
             gh.api.utilAPI.localDataStorage().store('collapsed', collapsedIds);
         });
     };

--- a/shared/gh/js/bootstrap.listview.js
+++ b/shared/gh/js/bootstrap.listview.js
@@ -23,25 +23,28 @@ define(['gh.api.util'], function(utilAPI) {
     /**
      * Update the list's collapsed status in the local storage
      *
-     * @param  {Number}     id           The id of the list
-     * @param  {Boolean}    collapsed    Whether or not the list is collapsed
+     * @param  {Object[]}    items    Collection of list items
      * @private
      */
-    var updateListCollapsedStatus = function(id, collapsed) {
+    var updateListCollapsedStatus = function(items) {
+
         // Fetch and parse the collapse listIds from the local storage
         var collapsedIds = utilAPI.localDataStorage().get('collapsed') || [];
 
-        // Add the listId to the local storage if collapsed
-        if (collapsed) {
-            collapsedIds.push(id);
+        _.each(items, function(item) {
 
-        // Remove the listId from the local storage if not collapsed
-        } else {
-            _.remove(collapsedIds, function(listId) { return listId === id; });
-        }
+            // Add the listId to the local storage if collapsed
+            if (item.collapsed) {
+                collapsedIds.push(item.id);
+
+            // Remove the listId from the local storage if not collapsed
+            } else {
+                _.remove(collapsedIds, function(listId) { return listId === item.id; });
+            }
+        });
 
         // Store the collapsed listIds
-        utilAPI.localDataStorage().store('collapsed', _.compact(collapsedIds));
+        utilAPI.localDataStorage().store('collapsed', _.uniq(_.compact(collapsedIds)));
     };
 
 
@@ -57,7 +60,16 @@ define(['gh.api.util'], function(utilAPI) {
         $(this).closest('.list-group-item').toggleClass('gh-list-group-item-open');
         // Toggle the caret class of the icon that was clicked
         $(this).find('i').toggleClass('fa-caret-right fa-caret-down');
-        // Update the list's collapsed status in the local storage
-        updateListCollapsedStatus($(this).closest('.list-group-item').attr('data-id'), $(this).closest('.list-group-item').hasClass('gh-list-group-item-open'));
+
+        // Fetch the id's of the collapsed list
+        var collapsedItems = $('#gh-modules-list > .list-group-item').map(function(index, module) {
+            return {
+                'id': $(module).attr('data-id'),
+                'collapsed': $(module).hasClass('gh-list-group-item-open')
+            };
+        });
+
+        // Store the collapsed list items
+        updateListCollapsedStatus(collapsedItems);
     });
 });


### PR DESCRIPTION
It looks like there's a problem with local storage where a couple of refreshes make it lose data.

To reproduce:

- Open a tripos/part with more than 1 module
- Expand both modules
- Refresh
- Observe that local storage correctly persisted and retrieved which modules where expanded
- Refresh
- Observe that the second module is now collapsed, without having collapsed it manually