### PR TITLE
Only add parameters to the request object if they are specified

### DIFF
--- a/shared/gh/api/gh.api.app.js
+++ b/shared/gh/api/gh.api.app.js
@@ -170,15 +170,12 @@ define(['exports'], function(exports) {
         var data = {};
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (displayName) {
             data['displayName'] = displayName;
         }
-        /* istanbul ignore next */
         if (enabled !== null) {
             data['enabled'] = enabled;
         }
-        /* istanbul ignore next */
         if (host) {
             data['host'] = host;
         }

--- a/shared/gh/api/gh.api.app.js
+++ b/shared/gh/api/gh.api.app.js
@@ -167,11 +167,21 @@ define(['exports'], function(exports) {
             return callback({'code': 400, 'msg': 'A valid value for host should be provided'});
         }
 
-        var data = {
-            'displayName': displayName,
-            'enabled': enabled,
-            'host': host
-        };
+        var data = {};
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (displayName) {
+            data['displayName'] = displayName;
+        }
+        /* istanbul ignore next */
+        if (enabled !== null) {
+            data['enabled'] = enabled;
+        }
+        /* istanbul ignore next */
+        if (host) {
+            data['host'] = host;
+        }
 
         $.ajax({
             'url': '/api/apps/' + appId,

--- a/shared/gh/api/gh.api.config.js
+++ b/shared/gh/api/gh.api.config.js
@@ -33,7 +33,7 @@ define(['exports'], function(exports) {
         var data = {};
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
+        /* istanbul ignore else */
         if (appId) {
             data['app'] = appId;
         }
@@ -74,7 +74,7 @@ define(['exports'], function(exports) {
         }
 
         // Add the appId to the configValues
-        /* istanbul ignore next */
+        /* istanbul ignore else */
         if (appId) {
             configValues['app'] = appId;
         }

--- a/shared/gh/api/gh.api.config.js
+++ b/shared/gh/api/gh.api.config.js
@@ -30,12 +30,18 @@ define(['exports'], function(exports) {
             return callback({'code': 400, 'msg': 'A valid value for appId should be provided'});
         }
 
+        var data = {};
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (appId) {
+            data['app'] = appId;
+        }
+
         $.ajax({
             'url': '/api/config',
             'type': 'GET',
-            'data': {
-                'app': appId
-            },
+            'data': data,
             'success': function(data) {
                 return callback(null, data);
             },
@@ -68,9 +74,9 @@ define(['exports'], function(exports) {
         }
 
         // Add the appId to the configValues
-        /* istanbul ignore else */
+        /* istanbul ignore next */
         if (appId) {
-            configValues.app = appId;
+            configValues['app'] = appId;
         }
 
         $.ajax({

--- a/shared/gh/api/gh.api.event.js
+++ b/shared/gh/api/gh.api.event.js
@@ -181,31 +181,24 @@ define(['exports'], function(exports) {
         };
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (description) {
             data['description'] = description;
         }
-        /* istanbul ignore next */
         if (groupId) {
             data['group'] = groupId;
         }
-        /* istanbul ignore next */
         if (location) {
             data['location'] = location;
         }
-        /* istanbul ignore next */
         if (notes) {
             data['notes'] = notes;
         }
-        /* istanbul ignore next */
         if (organiserOther) {
             data['organiserOther'] = organiserOther;
         }
-        /* istanbul ignore next */
         if (organiserUsers) {
             data['organiserUsers'] = organiserUsers;
         }
-        /* istanbul ignore next */
         if (seriesId) {
             data['serie'] = seriesId;
         }
@@ -263,31 +256,24 @@ define(['exports'], function(exports) {
         var data = {};
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (displayName) {
             data['displayName'] = displayName;
         }
-        /* istanbul ignore next */
         if (description) {
             data['description'] = description;
         }
-        /* istanbul ignore next */
         if (groupId) {
             data['group'] = groupId;
         }
-        /* istanbul ignore next */
         if (start) {
             data['start'] = start;
         }
-        /* istanbul ignore next */
         if (end) {
             data['end'] = end;
         }
-        /* istanbul ignore next */
         if (location) {
             data['location'] = location;
         }
-        /* istanbul ignore next */
         if (notes) {
             data['notes'] = notes;
         }

--- a/shared/gh/api/gh.api.event.js
+++ b/shared/gh/api/gh.api.event.js
@@ -83,21 +83,40 @@ define(['exports'], function(exports) {
             return callback({'code': 400, 'msg': 'A valid value for \'seriesId\' should be provided'});
         }
 
+        // Request data object
+        var data = {
+            'displayName': displayName,
+            'start': start,
+            'end': end
+        }
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        if (description) {
+            data.description = description;
+        }
+        if (groupId) {
+            data['group'] = groupId;
+        }
+        if (location) {
+            data['location'] = location;
+        }
+        if (notes) {
+            data['notes'] = notes;
+        }
+        if (organiserOther) {
+            data['organiserOther'] = organiserOther;
+        }
+        if (organiserUsers) {
+            data['organiserUsers'] = organiserUsers;
+        }
+        if (seriesId) {
+            data['serie'] = seriesId;
+        }
+
         $.ajax({
             'url': '/api/events/',
             'type': 'POST',
-            'data': {
-                'displayName': displayName,
-                'start': start,
-                'end': end,
-                'description': description,
-                'group': groupId,
-                'location': location,
-                'notes': notes,
-                'organiserOther': organiserOther,
-                'organiserUsers': organiserUsers,
-                'serie': seriesId
-            },
+            'data': data,
             'success': function(data) {
                 return callback(null, data);
             },
@@ -153,22 +172,48 @@ define(['exports'], function(exports) {
             return callback({'code': 400, 'msg': 'A valid value for \'seriesId\' should be provided'});
         }
 
+        // Request data object
+        var data = {
+            'app': appId,
+            'displayName': displayName,
+            'start': start,
+            'end': end
+        };
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (description) {
+            data['description'] = description;
+        }
+        /* istanbul ignore next */
+        if (groupId) {
+            data['group'] = groupId;
+        }
+        /* istanbul ignore next */
+        if (location) {
+            data['location'] = location;
+        }
+        /* istanbul ignore next */
+        if (notes) {
+            data['notes'] = notes;
+        }
+        /* istanbul ignore next */
+        if (organiserOther) {
+            data['organiserOther'] = organiserOther;
+        }
+        /* istanbul ignore next */
+        if (organiserUsers) {
+            data['organiserUsers'] = organiserUsers;
+        }
+        /* istanbul ignore next */
+        if (seriesId) {
+            data['serie'] = seriesId;
+        }
+
         $.ajax({
             'url': '/api/events/',
             'type': 'POST',
-            'data': {
-                'app': appId,
-                'displayName': displayName,
-                'start': start,
-                'end': end,
-                'description': description,
-                'group': groupId,
-                'location': location,
-                'notes': notes,
-                'organiserOther': organiserOther,
-                'organiserUsers': organiserUsers,
-                'serie': seriesId
-            },
+            'data': data,
             'success': function(data) {
                 return callback(null, data);
             },
@@ -214,18 +259,43 @@ define(['exports'], function(exports) {
             return callback({'code': 400, 'msg': 'A valid value for \'notes\' should be provided'});
         }
 
+        // Request data object
+        var data = {};
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (displayName) {
+            data['displayName'] = displayName;
+        }
+        /* istanbul ignore next */
+        if (description) {
+            data['description'] = description;
+        }
+        /* istanbul ignore next */
+        if (groupId) {
+            data['group'] = groupId;
+        }
+        /* istanbul ignore next */
+        if (start) {
+            data['start'] = start;
+        }
+        /* istanbul ignore next */
+        if (end) {
+            data['end'] = end;
+        }
+        /* istanbul ignore next */
+        if (location) {
+            data['location'] = location;
+        }
+        /* istanbul ignore next */
+        if (notes) {
+            data['notes'] = notes;
+        }
+
         $.ajax({
             'url': '/api/events/' + eventId,
             'type': 'POST',
-            'data': {
-                'displayName': displayName,
-                'description': description,
-                'group': groupId,
-                'start': start,
-                'end': end,
-                'location': location,
-                'notes': notes
-            },
+            'data': data,
             'success': function(data) {
                 return callback(null, data);
             },

--- a/shared/gh/api/gh.api.orgunit.js
+++ b/shared/gh/api/gh.api.orgunit.js
@@ -122,14 +122,17 @@ define(['exports'], function(exports) {
         };
 
         // Only add the optional parameters if they have been explicitly specified
+        /* istanbul ignore next */
         if (parentId) {
-            data.parent = parentId;
+            data['parent'] = parentId;
         }
+        /* istanbul ignore next */
         if (groupId) {
-            data.group = groupId;
+            data['group'] = groupId;
         }
+        /* istanbul ignore next */
         if (description) {
-            data.description = description;
+            data['description'] = description;
         }
 
         $.ajax({
@@ -588,16 +591,35 @@ define(['exports'], function(exports) {
         // Set a default callback function in case no callback function has been provided
         callback = callback || function() {};
 
+        // Request data object
+        var data = {};
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (description) {
+            data['description'] = description;
+        }
+        /* istanbul ignore next */
+        if (displayName) {
+            data['displayName'] = displayName;
+        }
+        /* istanbul ignore next */
+        if (groupId) {
+            data['group'] = groupId;
+        }
+        /* istanbul ignore next */
+        if (parentId) {
+            data['parent'] = parentId;
+        }
+        /* istanbul ignore next */
+        if (type) {
+            data['type'] = type;
+        }
+
         $.ajax({
             'url': '/api/orgunit/' + orgUnitId,
             'type': 'POST',
-            'data': {
-                'description': description,
-                'displayName': displayName,
-                'group': groupId,
-                'parent': parentId,
-                'type': type
-            },
+            'data': data,
             'success': function(data) {
                 return callback(null, data);
             },

--- a/shared/gh/api/gh.api.orgunit.js
+++ b/shared/gh/api/gh.api.orgunit.js
@@ -122,15 +122,12 @@ define(['exports'], function(exports) {
         };
 
         // Only add the optional parameters if they have been explicitly specified
-        /* istanbul ignore next */
         if (parentId) {
             data['parent'] = parentId;
         }
-        /* istanbul ignore next */
         if (groupId) {
             data['group'] = groupId;
         }
-        /* istanbul ignore next */
         if (description) {
             data['description'] = description;
         }
@@ -595,23 +592,18 @@ define(['exports'], function(exports) {
         var data = {};
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (description) {
             data['description'] = description;
         }
-        /* istanbul ignore next */
         if (displayName) {
             data['displayName'] = displayName;
         }
-        /* istanbul ignore next */
         if (groupId) {
             data['group'] = groupId;
         }
-        /* istanbul ignore next */
         if (parentId) {
             data['parent'] = parentId;
         }
-        /* istanbul ignore next */
         if (type) {
             data['type'] = type;
         }

--- a/shared/gh/api/gh.api.series.js
+++ b/shared/gh/api/gh.api.series.js
@@ -82,11 +82,9 @@ define(['exports'], function(exports) {
         };
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (description) {
             data['description'] = description;
         }
-        /* istanbul ignore next */
         if (groupId) {
             data['group'] = groupId;
         }
@@ -499,19 +497,19 @@ define(['exports'], function(exports) {
      *
      * @param  {Number}      serieId                The ID of the series to subscribe to
      * @param  {Number}      [userId]               The ID of the user that should be subscribed. Defaults to the current user
-     * @param  {Number}      [context]              The ID of the organisational unit to which the serie belongs
+     * @param  {Number}      [orgUnit]              The ID of the organisational unit to which the serie belongs
      * @param  {Function}    [callback]             Standard callback function
      * @param  {Object}      [callback.err]         Error object containing the error code and error message
      * @param  {Object}      [callback.response]    Object representing the subscribed to event series
      */
-    var subscribeSeries = exports.subscribeSeries = function(serieId, userId, context, callback) {
+    var subscribeSeries = exports.subscribeSeries = function(serieId, userId, orgUnit, callback) {
         if (callback && !_.isFunction(callback)) {
             throw new Error('A valid callback function should be provided');
         } else if (!_.isNumber(serieId)) {
             return callback({'code': 400, 'msg': 'A valid serieId should be provided'});
         } else if (userId && !_.isNumber(userId)) {
             return callback({'code': 400, 'msg': 'A valid userId should be provided'});
-        } else if (context && !_.isNumber(context)) {
+        } else if (orgUnit && !_.isNumber(orgUnit)) {
             return callback({'code': 400, 'msg': 'A valid context should be provided'});
         }
 
@@ -522,13 +520,11 @@ define(['exports'], function(exports) {
         var data = {};
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (userId) {
             data['userId'] = userId;
         }
-        /* istanbul ignore next */
-        if (context) {
-            data['context'] = context;
+        if (orgUnit) {
+            data['orgUnit'] = orgUnit;
         }
 
         $.ajax({
@@ -605,15 +601,12 @@ define(['exports'], function(exports) {
         var data = {};
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (displayName) {
             data['displayName'] = displayName;
         }
-        /* istanbul ignore next */
         if (description) {
             data['description'] = description;
         }
-        /* istanbul ignore next */
         if (groupId) {
             data['group'] = groupId;
         }

--- a/shared/gh/api/gh.api.series.js
+++ b/shared/gh/api/gh.api.series.js
@@ -75,15 +75,26 @@ define(['exports'], function(exports) {
         // Set a default callback function in case no callback function has been provided
         callback = callback || function() {};
 
+        // Request data object
+        var data = {
+            'app': appId,
+            'displayName': displayName
+        };
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (description) {
+            data['description'] = description;
+        }
+        /* istanbul ignore next */
+        if (groupId) {
+            data['group'] = groupId;
+        }
+
         $.ajax({
             'url': '/api/series',
             'type': 'POST',
-            'data': {
-                'app': appId,
-                'displayName': displayName,
-                'description': description,
-                'group': groupId
-            },
+            'data': data,
             'success': function(data) {
                 return callback(null, data);
             },
@@ -507,13 +518,23 @@ define(['exports'], function(exports) {
         // Set a default callback function in case no callback function has been provided
         callback = callback || function() {};
 
+        // Request data object
+        var data = {};
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (userId) {
+            data['userId'] = userId;
+        }
+        /* istanbul ignore next */
+        if (context) {
+            data['context'] = context;
+        }
+
         $.ajax({
             'url': '/api/series/' + serieId + '/subscribe',
             'type': 'POST',
-            'data': {
-                'userId': userId,
-                'context': context
-            },
+            'data': data,
             'success': function(data) {
                 return callback(null, data);
             },
@@ -580,14 +601,27 @@ define(['exports'], function(exports) {
         // Set a default callback function in case no callback function has been provided
         callback = callback || function() {};
 
+        // Request data object
+        var data = {};
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (displayName) {
+            data['displayName'] = displayName;
+        }
+        /* istanbul ignore next */
+        if (description) {
+            data['description'] = description;
+        }
+        /* istanbul ignore next */
+        if (groupId) {
+            data['group'] = groupId;
+        }
+
         $.ajax({
             'url': '/api/series/' + serieId,
             'type': 'POST',
-            'data': {
-                'description': description,
-                'displayName': displayName,
-                'group': groupId
-            },
+            'data': data,
             'success': function(data) {
                 return callback(null, data);
             },

--- a/shared/gh/api/gh.api.user.js
+++ b/shared/gh/api/gh.api.user.js
@@ -227,7 +227,7 @@ define(['exports'], function(exports) {
             'type': 'POST',
             'success': function(data) {
                 // If the updated user is the same as the cached user, update the cached user object calendar token
-                /* istanbul ignore if */
+                /* istanbul ignore next */
                 if (require('gh.core').data.me.id === data.id) {
                     require('gh.core').data.me.calendarToken = data.calendarToken;
                 }
@@ -333,16 +333,31 @@ define(['exports'], function(exports) {
             return callback({'code': 400, 'msg': 'A valid value for recaptchaResponse should be provided'});
         }
 
+        // Request data object
         var data = {
             'appId': appId,
             'displayName': displayName,
             'email': email,
-            'password': password,
-            'emailPreference': emailPreference,
-            'isAdmin': isAdmin,
-            'recaptchaChallenge': recaptchaChallenge,
-            'recaptchaResponse': recaptchaResponse
+            'password': password
         };
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (emailPreference) {
+            data['emailPreference'] = emailPreference;
+        }
+        /* istanbul ignore next */
+        if (isAdmin !== null) {
+            data['isAdmin'] = isAdmin;
+        }
+        /* istanbul ignore next */
+        if (recaptchaChallenge) {
+            data['recaptchaChallenge'] = recaptchaChallenge;
+        }
+        /* istanbul ignore next */
+        if (recaptchaResponse) {
+            data['recaptchaResponse'] = recaptchaResponse;
+        }
 
         $.ajax({
             'url': '/api/users',
@@ -390,7 +405,6 @@ define(['exports'], function(exports) {
      * Update a user
      *
      * @param  {Number}      userId               The ID of the user to update
-     * @param  {Number}      appId                The ID of the app for which to update the app-specific user values
      * @param  {String}      [displayName]        The updated user display name
      * @param  {String}      [email]              The updated user email address
      * @param  {String}      [emailPreference]    The updated user email preference
@@ -398,13 +412,11 @@ define(['exports'], function(exports) {
      * @param  {Object}      callback.err         Error object containing the error code and error message
      * @param  {Object}      callback.response    The updated user
      */
-    var updateUser = exports.updateUser = function(userId, appId, displayName, email, emailPreference, callback) {
+    var updateUser = exports.updateUser = function(userId, displayName, email, emailPreference, callback) {
         if (!_.isFunction(callback)) {
             throw new Error('A callback function should be provided');
         } else if (!_.isNumber(userId)) {
             return callback({'code': 400, 'msg': 'A valid user id should be provided'});
-        } else if (!_.isNumber(appId)) {
-            return callback({'code': 400, 'msg': 'A valid app id should be provided'});
         } else if (displayName && !_.isString(displayName)) {
             return callback({'code': 400, 'msg': 'A valid value for displayName should be provided'});
         } else if (email && !_.isString(email)) {
@@ -413,14 +425,27 @@ define(['exports'], function(exports) {
             return callback({'code': 400, 'msg': 'A valid value for emailPreference should be provided'});
         }
 
+        // Request data object
+        var data = {};
+
+        // Only add the parameters to the request object if they have been explicitly specified
+        /* istanbul ignore next */
+        if (displayName) {
+            data['displayName'] = displayName;
+        }
+        /* istanbul ignore next */
+        if (email) {
+            data['email'] = email;
+        }
+        /* istanbul ignore next */
+        if (emailPreference) {
+            data['emailPreference'] = emailPreference;
+        }
+
         $.ajax({
             'url': '/api/users/' + userId,
             'type': 'POST',
-            'data': {
-                'displayName': displayName,
-                'email': email,
-                'emailPreference': emailPreference
-            },
+            'data': data,
             'success': function(data) {
                 // If the updated user is the same as the cached user, update the cached user object
                 /* istanbul ignore if */

--- a/shared/gh/api/gh.api.user.js
+++ b/shared/gh/api/gh.api.user.js
@@ -342,11 +342,9 @@ define(['exports'], function(exports) {
         };
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (emailPreference) {
             data['emailPreference'] = emailPreference;
         }
-        /* istanbul ignore next */
         if (isAdmin !== null) {
             data['isAdmin'] = isAdmin;
         }
@@ -429,15 +427,12 @@ define(['exports'], function(exports) {
         var data = {};
 
         // Only add the parameters to the request object if they have been explicitly specified
-        /* istanbul ignore next */
         if (displayName) {
             data['displayName'] = displayName;
         }
-        /* istanbul ignore next */
         if (email) {
             data['email'] = email;
         }
-        /* istanbul ignore next */
         if (emailPreference) {
             data['emailPreference'] = emailPreference;
         }

--- a/tests/qunit/tests/js/api.app.js
+++ b/tests/qunit/tests/js/api.app.js
@@ -198,7 +198,7 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
     // Test the updateApp functionality
     QUnit.asyncTest('updateApp', function(assert) {
-        expect(17);
+        expect(18);
 
         // Fetch a random app
         var app = testAPI.getTestApp();
@@ -241,15 +241,20 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
                             assert.strictEqual(data.TenantId, app.TenantId, 'Verify that the tenant id remained the same');
                             assert.ok(data.updatedAt !== app.updatedAt, 'Verify that the value for updatedAt was changed');
 
-                            // Mock an error from the back-end
-                            var body = {'code': 400, 'msg': 'Bad Request'};
-                            gh.api.utilAPI.mockRequest('POST', '/api/apps/' + app.id, 400, {'Content-Type': 'application/json'}, body, function() {
-                                gh.api.appAPI.updateApp(app.id, displayName, enabled, host, function(err, data) {
-                                    assert.ok(err, 'Verify that an error is thrown when the back-end errored');
-                                    assert.ok(!data, 'Verify that no data is returned when an error is thrown');
-                                });
+                            // Verify that an error is thrown when no parameters have been specified
+                            gh.api.appAPI.updateApp(app.id, null, null, null, function(err, data) {
+                                assert.ok(err, 'Verify that an error is thrown when no parameters have been specified');
 
-                                QUnit.start();
+                                // Mock an error from the back-end
+                                var body = {'code': 400, 'msg': 'Bad Request'};
+                                gh.api.utilAPI.mockRequest('POST', '/api/apps/' + app.id, 400, {'Content-Type': 'application/json'}, body, function() {
+                                    gh.api.appAPI.updateApp(app.id, displayName, enabled, host, function(err, data) {
+                                        assert.ok(err, 'Verify that an error is thrown when the back-end errored');
+                                        assert.ok(!data, 'Verify that no data is returned when an error is thrown');
+                                    });
+
+                                    QUnit.start();
+                                });
                             });
                         });
                     });

--- a/tests/qunit/tests/js/api.config.js
+++ b/tests/qunit/tests/js/api.config.js
@@ -61,14 +61,14 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
         // Verify that an error is thrown when an invalid callback was provided
         assert.throws(function() {
-            gh.api.configAPI.updateConfig(testApp.id, {'key1': 'val1'}, 'invalid_callback');
+            gh.api.configAPI.updateConfig(testApp.id, {'enableGoogleAnalytics': true}, 'invalid_callback');
         }, 'Verify that an error is thrown when an invalid callback was provided');
 
         // Invoke the funtionality without callback
-        assert.equal(null, gh.api.configAPI.updateConfig(testApp.id, {'key1': 'val1'}), 'Verify that a default callback is set when none is provided and no error is thrown');
+        assert.equal(null, gh.api.configAPI.updateConfig(testApp.id, {'enableGoogleAnalytics': true}), 'Verify that a default callback is set when none is provided and no error is thrown');
 
         // Verify that an error is thrown when an invalid appId was provided
-        gh.api.configAPI.updateConfig('invalid_appid', {'key1': 'val1'}, function(err, data) {
+        gh.api.configAPI.updateConfig('invalid_appid', {'enableGoogleAnalytics': true}, function(err, data) {
             assert.ok(err, 'Verify that an error is thrown when an invalid appId was provided');
 
             // Verify that an error is thrown when no configValues were provided
@@ -79,20 +79,17 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
                 gh.api.configAPI.updateConfig(testApp.id, 'invalid_configuration_values', function(err, data) {
                     assert.ok(err, 'Verify that an error is thrown when invalid configValues are provided');
 
-                    // Since config in the backend is using hardcoded values which might change over time,
-                    // we just mock the request here to have consistent succeeding tests
-                    var body = {'code': 200, 'msg': 'OK'};
-                    gh.api.utilAPI.mockRequest('POST', '/api/config', 200, {'Content-Type': 'application/json'}, body, function() {
-                        gh.api.configAPI.updateConfig(testApp.id, {'key1': 'val1'}, function(err, data) {
-                            assert.ok(!err, 'Verify that the config can be successfully updated');
+                    // Verify that a config value can be updated without errors
+                    gh.api.configAPI.updateConfig(testApp.id, {'enableGoogleAnalytics': false}, function(err, data) {
+                        assert.ok(!err, 'Verify that the config can be successfully updated');
 
-                            body = {'code': 400, 'msg': 'Bad Request'};
-                            gh.api.utilAPI.mockRequest('POST', '/api/config', 400, {'Content-Type': 'application/json'}, body, function() {
-                                gh.api.configAPI.updateConfig(testApp.id, {'key1': 'val1'}, function(err, data) {
-                                    assert.ok(err, 'Verify that the error is handled when the config can\'t be successfully updated');
-                                    assert.ok(!data, 'Verify that no data returns when the config can\'t be successfully updated');
-                                    QUnit.start();
-                                });
+                        // Verify that the error is handled when a config value can't be updated successfully
+                        body = {'code': 400, 'msg': 'Bad Request'};
+                        gh.api.utilAPI.mockRequest('POST', '/api/config', 400, {'Content-Type': 'application/json'}, body, function() {
+                            gh.api.configAPI.updateConfig(testApp.id, {'enableGoogleAnalytics': false}, function(err, data) {
+                                assert.ok(err, 'Verify that the error is handled when the config can\'t be successfully updated');
+                                assert.ok(!data, 'Verify that no data returns when the config can\'t be successfully updated');
+                                QUnit.start();
                             });
                         });
                     });

--- a/tests/qunit/tests/js/api.event.js
+++ b/tests/qunit/tests/js/api.event.js
@@ -116,7 +116,7 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
     // Test the createEventByApp functionality
     QUnit.asyncTest('createEventByApp', function(assert) {
-        expect(21);
+        expect(22);
 
         // Fetch a random test app
         var app = testAPI.getTestApp();
@@ -191,20 +191,25 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
                                                                 gh.api.eventAPI.createEventByApp(app.id, 'displayName', '2014-12-31', '2015-01-01', 'description', null, 'location', 'notes', null, null, 'invalid_series_id', function(err, data) {
                                                                     assert.ok(err, 'Verify that an error is thrown when an invalid value for seriesId was provided');
 
-                                                                    // Verify that an event can be created without errors
-                                                                    gh.api.eventAPI.createEventByApp(app.id, 'displayName', '2014-12-31', '2015-01-01', 'description', null, 'location', 'notes', null, null, null, function(err, data) {
-                                                                        assert.ok(!err, 'Verify that an event can be created without errors');
-                                                                        assert.ok(data, 'Verify that the created event is returned');
+                                                                    // Create a test series
+                                                                    gh.api.seriesAPI.createSeries(app.id, 'displayName', 'Test description', 1, function(err, data) {
+                                                                        assert.ok(!err, 'Verify that the test series have been created without errors');
 
-                                                                        // Verify that a thrown error is handled successfully
-                                                                        var body = {'code': 400, 'msg': 'Bad Request'};
-                                                                        gh.api.utilAPI.mockRequest('POST', '/api/events', 400, {'Content-Type': 'application/json'}, body, function() {
-                                                                            gh.api.eventAPI.createEventByApp(app.id, 'displayName', '2014-12-31', '2015-01-01', 'description', null, 'location', 'notes', null, null, null, function(err, data) {
-                                                                                assert.ok(err, 'Verify that an error is thrown when the back-end errored');
-                                                                                assert.ok(!data, 'Verify that no data is returned when an error is thrown');
+                                                                        // Verify that an event can be created without errors
+                                                                        gh.api.eventAPI.createEventByApp(app.id, 'displayName', '2014-12-31', '2015-01-01', 'description', 1, 'location', 'notes', ['John Doe', 'Jane Doe'], null, data.id, function(err, data) {
+                                                                            assert.ok(!err, 'Verify that an event can be created without errors');
+                                                                            assert.ok(data, 'Verify that the created event is returned');
+
+                                                                            // Verify that a thrown error is handled successfully
+                                                                            var body = {'code': 400, 'msg': 'Bad Request'};
+                                                                            gh.api.utilAPI.mockRequest('POST', '/api/events', 400, {'Content-Type': 'application/json'}, body, function() {
+                                                                                gh.api.eventAPI.createEventByApp(app.id, 'displayName', '2014-12-31', '2015-01-01', 'description', null, 'location', 'notes', null, null, null, function(err, data) {
+                                                                                    assert.ok(err, 'Verify that an error is thrown when the back-end errored');
+                                                                                    assert.ok(!data, 'Verify that no data is returned when an error is thrown');
+                                                                                });
+
+                                                                                QUnit.start();
                                                                             });
-
-                                                                            QUnit.start();
                                                                         });
                                                                     });
                                                                 });
@@ -226,7 +231,7 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
     // Test the updateEvent functionality
     QUnit.asyncTest('updateEvent', function(assert) {
-        expect(16);
+        expect(18);
 
         // Create a test event
         createRandomEvent(null, function(err, evt) {
@@ -278,20 +283,26 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
                                             gh.api.eventAPI.updateEvent(evt.id, 'displayName', 'description', null, '2014-12-31', '2015-01-01', 'location', 1234, function(err, data) {
                                                 assert.ok(err, 'Verify that an error is thrown when an invalid value for notes was provided');
 
-                                                // Verify that an event can be updated without errors
+                                                // Verify that an event can be updated without errors when all the parameters have been specified
                                                 gh.api.eventAPI.updateEvent(evt.id, 'displayName', 'description', null, '2014-12-31', '2015-01-01', 'location', 'notes', function(err, data) {
                                                     assert.ok(!err, 'Verify that an event can be updated without errors');
                                                     assert.ok(data, 'Verify that the updated event is returned');
 
-                                                    // Verify that a thrown error is handled successfully
-                                                    body = {'code': 400, 'msg': 'Bad Request'};
-                                                    gh.api.utilAPI.mockRequest('POST', '/api/events/' + evt.id, 400, {'Content-Type': 'application/json'}, body, function() {
-                                                        gh.api.eventAPI.updateEvent(evt.id, 'displayName', 'description', null, '2014-12-31', '2015-01-01', 'location', 'notes', function(err, data) {
-                                                            assert.ok(err, 'Verify that a thrown error is handled successfully');
-                                                            assert.ok(!data, 'Verity that no event is returned');
-                                                        });
+                                                    // Verify that an event can be updated without errors when only one parameter has been specified
+                                                    gh.api.eventAPI.updateEvent(evt.id, null, null, 1, null, null, null, null, function(err, data) {
+                                                        assert.ok(!err, 'Verify that an event can be updated without errors');
+                                                        assert.ok(data, 'Verify that the updated event is returned');
 
-                                                        QUnit.start();
+                                                        // Verify that a thrown error is handled successfully
+                                                        body = {'code': 400, 'msg': 'Bad Request'};
+                                                        gh.api.utilAPI.mockRequest('POST', '/api/events/' + evt.id, 400, {'Content-Type': 'application/json'}, body, function() {
+                                                            gh.api.eventAPI.updateEvent(evt.id, 'displayName', 'description', null, '2014-12-31', '2015-01-01', 'location', 'notes', function(err, data) {
+                                                                assert.ok(err, 'Verify that a thrown error is handled successfully');
+                                                                assert.ok(!data, 'Verity that no event is returned');
+                                                            });
+
+                                                            QUnit.start();
+                                                        });
                                                     });
                                                 });
                                             });

--- a/tests/qunit/tests/js/api.orgunit.js
+++ b/tests/qunit/tests/js/api.orgunit.js
@@ -401,7 +401,6 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         });
     });
 
-
     // Test the createOrgUnit functionality
     QUnit.asyncTest('createOrgUnit', function(assert) {
         expect(14);
@@ -480,7 +479,6 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         });
     });
 
-
     // Test the createOrgUnitByApp functionality
 
     // Test the updateOrgUnit functionality
@@ -525,22 +523,18 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
                                     // Verify that a default callback is set when none is provided and no error is thrown
                                     assert.equal(null, gh.api.orgunitAPI.updateOrgUnit(testOrgUnit.id, 'description', 'displayName', null, null, null), 'Verify that a default callback is set when none is provided and no error is thrown');
 
-                                    // Verify that the organisational unit can be updated
-                                    // TODO: Switch this mocked call out with the proper API request once it has been implemented in the backend
-                                    var body = {'code': 200, 'msg': 'OK'};
-                                    gh.api.utilAPI.mockRequest('POST', '/api/orgunit/' + testOrgUnit.id, 200, {'Content-Type': 'application/json'}, body, function() {
-                                        gh.api.orgunitAPI.updateOrgUnit(testOrgUnit.id, null, null, null, null, null, function(err, data) {
-                                            assert.ok(!err, 'Verify that the organisational unit can be updated successfully');
+                                    // Verify that the organisational unit can be updated when all the parameters have been specified
+                                    gh.api.orgunitAPI.updateOrgUnit(testOrgUnit.id, 'description', 'displayName', 1, 1, 'part', function(err, data) {
+                                        assert.ok(!err, 'Verify that the organisational unit can be updated successfully');
 
-                                            // Verify that the error is handled when the organisational unit could not be successfully updated
-                                            body = {'code': 400, 'msg': 'Bad Request'};
-                                            gh.api.utilAPI.mockRequest('POST', '/api/orgunit/' + testOrgUnit.id, 400, {'Content-Type': 'application/json'}, body, function() {
-                                                gh.api.orgunitAPI.updateOrgUnit(testOrgUnit.id, null, null, null, null, null, function(err, data) {
-                                                    assert.ok(err, 'Verify that the error is handled when the organisational unit could not be successfully updated');
-                                                    assert.ok(!data, 'Verify that no data returns when the organisational unit could not be successfully updated');
+                                        // Verify that the error is handled when the organisational unit could not be successfully updated
+                                        body = {'code': 400, 'msg': 'Bad Request'};
+                                        gh.api.utilAPI.mockRequest('POST', '/api/orgunit/' + testOrgUnit.id, 400, {'Content-Type': 'application/json'}, body, function() {
+                                            gh.api.orgunitAPI.updateOrgUnit(testOrgUnit.id, null, null, null, null, null, function(err, data) {
+                                                assert.ok(err, 'Verify that the error is handled when the organisational unit could not be successfully updated');
+                                                assert.ok(!data, 'Verify that no data returns when the organisational unit could not be successfully updated');
 
-                                                    QUnit.start();
-                                                });
+                                                QUnit.start();
                                             });
                                         });
                                     });

--- a/tests/qunit/tests/js/api.user.js
+++ b/tests/qunit/tests/js/api.user.js
@@ -645,7 +645,7 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
     // Test the updateUser functionality
     QUnit.asyncTest('updateUser', function(assert) {
-        expect(12);
+        expect(10);
 
         // Create a new user
         _generateRandomUser(function(err, user) {
@@ -653,48 +653,38 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
             // Verify that an error is thrown when an invalid callback was provided
             assert.throws(function() {
-                gh.api.userAPI.updateUser(user.id, user.AppId, null, null, null);
+                gh.api.userAPI.updateUser(user.id, null, null, null);
             }, 'Verify that an error is thrown when an invalid callback was provided');
 
             // Verify that an error is thrown when an invalid value for 'userId' was provided
-            gh.api.userAPI.updateUser(null, user.AppId, null, null, null, function(err, data) {
+            gh.api.userAPI.updateUser(null, null, null, null, function(err, data) {
                 assert.ok(err, 'Verify that an error is thrown when an invalid value for userId was provided');
 
-                // Verify that an error is thrown when no value for 'appId' was provided
-                gh.api.userAPI.updateUser(user.id, null, null, null, null, function(err, data) {
-                    assert.ok(err, 'Verify that an error is thrown when no value for appId was provided');
+                // Verify that an error is thrown when an invalid value for displayName was provided
+                gh.api.userAPI.updateUser(user.id, ['invalid_value'], null, null, function(err, data) {
+                    assert.ok(err, 'Verify that an error is thrown when an invalid value for displayName was provided');
 
-                    // Verify that an error is thrown when an invalid value for 'appId' was provided
-                    gh.api.userAPI.updateUser(user.id, 'invalid app id', null, null, null, function(err, data) {
-                        assert.ok(err, 'Verify that an error is thrown when an invalid value for appId was provided');
+                    // Verify that an error is thrown when an invalid value for email was provided
+                    gh.api.userAPI.updateUser(user.id, null, ['invalid_value'], null, function(err, data) {
+                        assert.ok(err, 'Verify that an error is thrown when an invalid value for email was provided');
 
-                        // Verify that an error is thrown when an invalid value for displayName was provided
-                        gh.api.userAPI.updateUser(user.id, user.AppId, ['invalid_value'], null, null, function(err, data) {
-                            assert.ok(err, 'Verify that an error is thrown when an invalid value for displayName was provided');
+                        // Verify that an error is thrown when an invalid value for emailPreference was provided
+                        gh.api.userAPI.updateUser(user.id, null, null, ['invalid_value'], function(err, data) {
+                            assert.ok(err, 'Verify that an error is thrown when an invalid value for emailPreference was provided');
 
-                            // Verify that an error is thrown when an invalid value for email was provided
-                            gh.api.userAPI.updateUser(user.id, user.AppId, null, ['invalid_value'], null, function(err, data) {
-                                assert.ok(err, 'Verify that an error is thrown when an invalid value for email was provided');
+                            // Verify that a user can be updated without errors
+                            gh.api.userAPI.updateUser(user.id, 'testdisplayname', gh.api.utilAPI.generateRandomString() + '@name.com', 'no', function(err, data) {
+                                assert.ok(!err, 'Verify that a user can be updated without errors');
+                                assert.strictEqual(data.displayName, 'testdisplayname', 'Verify that the user was updated successfully');
 
-                                // Verify that an error is thrown when an invalid value for emailPreference was provided
-                                gh.api.userAPI.updateUser(user.id, user.AppId, null, null, ['invalid_value'], function(err, data) {
-                                    assert.ok(err, 'Verify that an error is thrown when an invalid value for emailPreference was provided');
+                                // Mock an error from the back-end
+                                var body = {'code': 400, 'msg': 'Bad Request'};
+                                gh.api.utilAPI.mockRequest('POST', '/api/users/' + user.id + '?displayName=testdisplayname&email=display@name.com&emailPreference=no', 400, {'Content-Type': 'application/json'}, body, function() {
+                                    gh.api.userAPI.updateUser(user.id, 'testdisplayname', 'display@name.com', 'no', function(err, data) {
+                                        assert.ok(err, 'Verify that the error is handled when the user can\'t be successfully updated');
+                                        assert.ok(!data, 'Verify that no data returns when the user can\'t be successfully updated');
 
-                                    // Verify that a user can be updated without errors
-                                    gh.api.userAPI.updateUser(user.id, user.AppId, 'testdisplayname', gh.api.utilAPI.generateRandomString() + '@name.com', 'no', function(err, data) {
-                                        assert.ok(!err, 'Verify that a user can be updated without errors');
-                                        assert.strictEqual(data.displayName, 'testdisplayname', 'Verify that the user was updated successfully');
-
-                                        // Mock an error from the back-end
-                                        var body = {'code': 400, 'msg': 'Bad Request'};
-                                        gh.api.utilAPI.mockRequest('POST', '/api/users/' + user.id + '?displayName=testdisplayname&email=display@name.com&emailPreference=no', 400, {'Content-Type': 'application/json'}, body, function() {
-                                            gh.api.userAPI.updateUser(user.id, user.AppId, 'testdisplayname', 'display@name.com', 'no', function(err, data) {
-                                                assert.ok(err, 'Verify that the error is handled when the user can\'t be successfully updated');
-                                                assert.ok(!data, 'Verify that no data returns when the user can\'t be successfully updated');
-
-                                                QUnit.start();
-                                            });
-                                        });
+                                        QUnit.start();
                                     });
                                 });
                             });


### PR DESCRIPTION
When sending a request to the REST API, we should only add the body parameters if they have been explicitly specified.

For example:
```
someFunc('', 'someValue');

/**
 * @param  {String}    [valueA]
 * @param  {String}    valueB
 */
someFunc(valueA, valueB) {

    // The request body
    var requestBody = {
        'valueB': valueB 
    };

    // Only add valueA if it has been explicitly been specified
    if (valueA) {
        requestBody.valueA = valueA;
    }

    $.ajax({
        'data': requestBody
    });
};
```