### PR TITLE
Error when accessing global admin panel as anonymous user

### DIFF
--- a/apps/admin/ui/js/index.js
+++ b/apps/admin/ui/js/index.js
@@ -447,7 +447,7 @@ define(['gh.core', 'gh.calendar', 'chosen', 'jquery-bbq'], function(gh) {
         renderHeader();
         // Determine which page to load based on the login state and
         // page the user's on
-        if (gh.data && gh.data.me) {
+        if (gh.data && !gh.data.me.anon) {
             // Show the right content, depending on the page the user's on
             if (currentPage === 'configuration') {
                 setUpConfig();


### PR DESCRIPTION
An error is thrown when accessing the global administrator panel when the user is not logged in: `Uncaught TypeError: Cannot read property 'length' of undefined`