### PR TITLE
Split up events in batch edit into terms

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -279,7 +279,6 @@
 /*****************/
 
 #gh-batch-edit-container {
-    background: #FFF;
     padding: 30px;
     width: 100%;
 }

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -279,7 +279,29 @@
 /*****************/
 
 #gh-batch-edit-container {
-    margin: 30px;
+    background: #FFF;
+    padding: 30px;
+    width: 100%;
+}
+
+#gh-batch-edit-container.gh-sticky-header {
+    -webkit-box-shadow: 0 6px 37px;
+       -moz-box-shadow: 0 6px 37px;
+            box-shadow: 0 6px 37px;
+    position: fixed;
+    top: 0;
+    width: calc(100% - 320px);
+    z-index: 1;
+}
+
+#gh-batch-edit-container.gh-sticky-header + #gh-batch-edit-term-container {
+    margin-top: 150px;
+}
+
+#gh-batch-edit-container::after {
+    clear: both;
+    content: '';
+    display: block;
 }
 
 #gh-batch-edit-container h1 {
@@ -299,15 +321,23 @@
     width: 100%;
 }
 
-.gh-batch-edit-events-container {
+#gh-batch-edit-term-container {
+    margin: 0 30px 30px;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container {
+    margin-bottom: 30px;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container:last-child {
     margin-bottom: 100px;
 }
 
-.gh-batch-edit-events-container .table > thead > tr > th {
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th {
     border-bottom-width: 5px;
 }
 
-.gh-batch-edit-events-container .table > tbody > tr > td {
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td {
     cursor: pointer;
     max-width: 200px;
     overflow: hidden;
@@ -317,31 +347,31 @@
     white-space: nowrap;
 }
 
-.gh-batch-edit-events-container .table > tbody > tr > td:first-child {
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td:first-child {
     cursor: auto;
     max-width: 40px;
 }
 
-.gh-batch-edit-events-container .table > thead > tr > th .checkbox,
-.gh-batch-edit-events-container .table > tbody > tr > td .checkbox {
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td .checkbox {
     margin: 0;
 }
 
-.gh-batch-edit-events-container .table > thead > tr > th .checkbox {
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox {
     margin-left: 5px;
 }
 
-.gh-batch-edit-events-container .table > thead > tr > th .checkbox input,
-.gh-batch-edit-events-container .table > tbody > tr > td .checkbox input {
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox input,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td .checkbox input {
     margin-top: 2px;
 }
 
-.gh-batch-edit-events-container .gh-jeditable-form {
+#gh-batch-edit-term-container .gh-batch-edit-events-container .gh-jeditable-form {
     margin: -8px -12px;
     height: 30px;
 }
 
-.gh-batch-edit-events-container .gh-jeditable-form input {
+#gh-batch-edit-term-container .gh-batch-edit-events-container .gh-jeditable-form input {
     border: none;
     border-left-style: solid;
     border-left-width: 1px;
@@ -362,7 +392,6 @@
     -webkit-box-shadow: 0 6px 37px;
        -moz-box-shadow: 0 6px 37px;
             box-shadow: 0 6px 37px;
-    margin-left: -30px;
     padding: 20px;
     position: fixed;
     width: -moz-calc(100% - 320px); /* Firefox */

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -191,6 +191,10 @@
 /* BATCH EDITING */
 /*****************/
 
+#gh-batch-edit-container {
+    background-color: #FFF;
+}
+
 .gh-batch-edit-events-container .table > tbody > tr.info td {
     background-color: #ECF5F9;
 }

--- a/apps/timetable/admin/ui/js/index.js
+++ b/apps/timetable/admin/ui/js/index.js
@@ -178,7 +178,9 @@ define(['gh.core', 'gh.admin-constants', 'gh.subheader', 'gh.calendar', 'gh.admi
      * @private
      */
     var renderBatchEdit = function(data) {
+        // Split the events by term
         data.eventsByTerm = gh.api.utilAPI.splitEventsByTerm(data.events);
+        // Delete the events object as it's been parsed into a different object
         delete data.events;
         gh.api.utilAPI.renderTemplate($('#gh-batch-edit-template'), {
             'gh': gh,

--- a/apps/timetable/admin/ui/js/index.js
+++ b/apps/timetable/admin/ui/js/index.js
@@ -178,6 +178,8 @@ define(['gh.core', 'gh.admin-constants', 'gh.subheader', 'gh.calendar', 'gh.admi
      * @private
      */
     var renderBatchEdit = function(data) {
+        data.eventsByTerm = gh.api.utilAPI.splitEventsByTerm(data.events);
+        delete data.events;
         gh.api.utilAPI.renderTemplate($('#gh-batch-edit-template'), {
             'gh': gh,
             'data': data

--- a/shared/gh/api/gh.api.util.js
+++ b/shared/gh/api/gh.api.util.js
@@ -286,6 +286,52 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
         return Math.round(difference / (60 * 60 * 24 * 7));
     };
 
+    /**
+     * Split up a given Array of events into separate Arrays per term. Returns an object with
+     * keys being the term label and values the Array of events associated to that term
+     *
+     * @param  {Event[]}    events    The Array of events to split up into terms
+     *
+     * @return {Object}        Object representing the split up terms and events
+     */
+    var splitEventsByTerm = exports.splitEventsByTerm = function(events) {
+        // Get the configuration
+        var config = require('gh.core').config;
+        // Get the correct terms associated to the current application
+        var terms = config.terms[config.academicYear];
+        // Create the object to return
+        var eventsByTerm = {};
+
+        // Transform the start and end dates in the terms to proper Date objects so we can
+        // compare them to the start times of the events. Also add a key to the object to
+        // return in which we will add the triaged events
+        _.each(terms, function(term) {
+            // Convert start and end strings into proper dates for comparison
+            term.start = new Date(term.start);
+            term.end = new Date(term.end);
+            // Add an Array to the object to return with the term label as the key
+            eventsByTerm[term.label] = [];
+        });
+
+        // Loop over the array of events to triage them
+        _.each(events.results, function(ev) {
+            // Convert start date into proper date for comparison
+            var evStart = new Date(ev.start);
+            // Loop over the terms and check whether the event start date
+            // falls between the term start and end date. If it does, push
+            // it into the term's Array
+            _.each(terms, function(term) {
+                if (evStart >= term.start && evStart <= term.end) {
+                    // The event takes place in this term, push it into the Array
+                    eventsByTerm[term.label].push(ev);
+                }
+            });
+        });
+
+        // Return the resulting object
+        return eventsByTerm;
+    };
+
 
     ///////////////
     //  GENERAL  //

--- a/shared/gh/js/controller/gh.admin-batch-edit.js
+++ b/shared/gh/js/controller/gh.admin-batch-edit.js
@@ -35,8 +35,9 @@ define(['gh.api.series', 'gh.api.util', 'gh.api.event', 'gh.admin-constants', 'm
      * @private
      */
     var addNewEventRow = function() {
+        $eventContainer = $(this).closest('thead').next('tbody');
         // Append a new event row
-        $('tbody').append(utilAPI.renderTemplate($('#gh-batch-edit-event-row-template'), {
+        $eventContainer.append(utilAPI.renderTemplate($('#gh-batch-edit-event-row-template'), {
             'ev': {
                 'tempId': utilAPI.generateRandomString(), // The actual ID hasn't been generated yet
                 'isNew': true, // Used in the template to know this one needs special handling
@@ -148,6 +149,25 @@ define(['gh.api.series', 'gh.api.util', 'gh.api.event', 'gh.admin-constants', 'm
         var key = parseInt(ev.which, 10);
         if (key === 32 || key === 13) {
             $(this).click();
+        }
+    };
+
+    /**
+     * Make the header stick to the top of the page, depending on how far
+     * down the page is scrolled
+     *
+     * @private
+     */
+    var handleStickyHeader = function() {
+        // Get the top of the window and the top of the header's position
+        var windowTop = $(window).scrollTop();
+        var headerTop = $('#gh-sticky-header-anchor').offset().top;
+        // If the window is scrolled further down than the header was originally
+        // positioned, make the header sticky
+        if (windowTop > headerTop) {
+            $('#gh-batch-edit-container').addClass('gh-sticky-header');
+        } else {
+            $('#gh-batch-edit-container').removeClass('gh-sticky-header');
         }
     };
 
@@ -612,6 +632,7 @@ define(['gh.api.series', 'gh.api.util', 'gh.api.event', 'gh.admin-constants', 'm
         // Setup
         $(document).on('gh.batchedit.setup', loadSeriesEvents);
         $(document).on('gh.batchedit.rendered', setUpJEditable);
+        $(window).scroll(handleStickyHeader);
 
         // External edit
         $(document).on('gh.datepicker.change', batchEditDate);

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -1,5 +1,4 @@
-<div id="gh-batch-edit-view" class="gh-main-view">
-
+<div class="gh-main-view">
     <div id="gh-toolbar-container">
         <div class="gh-toolbar gh-toolbar-primary">
             <div id="gh-calendar-toolbar-views" class="gh-toolbar-views pull-left">
@@ -9,7 +8,7 @@
         </div>
     </div>
 
-    <!-- Calendar -->
+    <div id="gh-sticky-header-anchor"></div>
     <div id="gh-batch-edit-container">
         <ul class="nav nav-pills pull-right" role="tablist">
             <li role="presentation" class="dropdown">
@@ -56,44 +55,43 @@
             </div>
             <div class="col-xs-1"></div>
         </div>
+    </div>
 
-        <div class="gh-batch-edit-events-container">
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th class="col-xs-1">
-                            <div class="checkbox">
-                                <label>
-                                    <input type="checkbox" class="gh-select-all"> Michaelmas
-                                </label>
-                            </div>
-                        </th>
-                        <th class="col-xs-2"></th>
-                        <th class="col-xs-2"></th>
-                        <th class="col-xs-2"></th>
-                        <th class="col-xs-2"></th>
-                        <th class="col-xs-2"></th>
-                        <th class="col-xs-1">
-                            <button type="button" class="btn btn-default pull-right gh-btn-secondary gh-new-event"><i class="fa fa-plus-square"></i> Add event</button>
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                <% _.each(data.events.results, function(ev) { %>
-                    <%= _.partial('admin-batch-edit-event-row', {
-                        'ev': ev,
-                        'gh': gh,
-                        'utilAPI': gh.api.utilAPI
-                    }) %>
-                <% }); %>
-                </tbody>
-            </table>
-        </div>
+    <div id="gh-batch-edit-term-container">
+        <% _.each(data.eventsByTerm, function(term, name) { %>
+            <div class="gh-batch-edit-events-container">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th class="col-xs-1" colspan="6">
+                                <div class="checkbox">
+                                    <label>
+                                        <input type="checkbox" class="gh-select-all"> <%- name %>
+                                    </label>
+                                </div>
+                            </th>
+                            <th class="col-xs-1">
+                                <button type="button" class="btn btn-default pull-right gh-btn-secondary gh-new-event"><i class="fa fa-plus-square"></i> Add event</button>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <% _.each(term, function(ev) { %>
+                        <%= _.partial('admin-batch-edit-event-row', {
+                            'ev': ev,
+                            'gh': gh,
+                            'utilAPI': gh.api.utilAPI
+                        }) %>
+                    <% }); %>
+                    </tbody>
+                </table>
+            </div>
+        <% }); %>
+    </div>
 
-        <div class="gh-batch-edit-actions-container" style="display: none;">
-            <p id="gh-batch-edit-change-summary" class="pull-left"></p>
-            <button type="button" id="gh-batch-edit-submit" class="btn btn-default pull-right">Save</button>
-            <button type="button" class="btn btn-link pull-right" data-dismiss="modal">Cancel</button>
-        </div>
+    <div class="gh-batch-edit-actions-container" style="display: none;">
+        <p id="gh-batch-edit-change-summary" class="pull-left"></p>
+        <button type="button" id="gh-batch-edit-submit" class="btn btn-default pull-right">Save</button>
+        <button type="button" class="btn btn-link pull-right" data-dismiss="modal">Cancel</button>
     </div>
 </div>

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -306,6 +306,65 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         assert.equal(2, numWeeks);
     });
 
+    // Test the 'splitEventsByTerm' functionality
+    QUnit.test('splitEventsByTerm', function(assert) {
+        expect(4);
+
+        // Mock a configuration object to test with
+        require('gh.core').config = {
+            "terms": {
+                "2014": [
+                    {
+                        "name": "michaelmas",
+                        "label": "Michaelmas",
+                        "start": "2014-10-07T00:00:00.000Z",
+                        "end": "2014-12-04T00:00:00.000Z"
+                    },
+                    {
+                        "name": "lent",
+                        "label": "Lent",
+                        "start": "2015-01-13T00:00:00.000Z",
+                        "end": "2015-03-13T00:00:00.000Z"
+                    },
+                    {
+                        "name": "easter",
+                        "label": "Easter",
+                        "start": "2015-04-21T00:00:00.000Z",
+                        "end": "2015-06-12T00:00:00.000Z"
+                    }
+                ]
+            },
+            'academicYear': 2014
+        };
+
+        // Mock an Array of events to test with
+        var events = {
+            "results": [
+                { // Michaelmas
+                    "end": "2014-10-20T14:00:00.000Z",
+                    "start": "2014-10-20T13:00:00.000Z"
+                },
+                { // Lent
+                    "end": "2015-01-30T11:00:00.000Z",
+                    "start": "2015-01-30T10:00:00.000Z"
+                },
+                { // Easter
+                    "end": "2015-04-30T14:00:00.000Z",
+                    "start": "2015-04-30T13:00:00.000Z"
+                }
+            ]
+        };
+
+        // Split the events by term
+        var eventsByTerm = gh.api.utilAPI.splitEventsByTerm(events);
+
+        // Verify that the returning events were correctly split by term
+        assert.ok(eventsByTerm, 'Verify that events can be successfully split by term');
+        assert.equal(eventsByTerm['Michaelmas'].length, 1, 'Verify that 1 event was triaged into Michaelmas');
+        assert.equal(eventsByTerm['Lent'].length, 1, 'Verify that 1 event was triaged into Lent');
+        assert.equal(eventsByTerm['Easter'].length, 1, 'Verify that 1 event was triaged into Easter');
+    });
+
 
     ///////////////
     //  GENERAL  //


### PR DESCRIPTION
Now that we have the necessary configuration in place, we should split up events per term in batch edit.