### PR TITLE
Calculate the week number in batch edit

### DIFF
--- a/shared/gh/api/gh.api.util.js
+++ b/shared/gh/api/gh.api.util.js
@@ -96,7 +96,7 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
         }
 
         // TODO: add the week number when the custom configuration is in place
-        var weekNumber = 'W?';
+        var weekNumber = 'W' + getWeekInTerm(startDate);
 
         // Retrieve the day
         var weekDay = moment(endDate).utc().format('E');
@@ -130,6 +130,47 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
 
         // Return the display date
         return String(weekNumber + ' · ' + weekDay + ' ' + startParts + '-' + endParts);
+    };
+
+    /**
+     * Get the week of the term in which a date is located. The function assumes that the
+     * week starts on the first day of the term and that the terms are limited by the
+     * academicYear that is set on the app
+     *
+     * @param  {String|Date}    date    The date to find the week number in the term for
+     * @return {Number}                 The week number of the term the given date is in
+     * @private
+     */
+    var getWeekInTerm = exports.getWeekInTerm = function(date) {
+        // Get the configuration
+        var config = require('gh.core').config;
+        // Get the correct terms associated to the current application
+        var terms = config.terms[config.academicYear];
+        // Variable used to assign the week number to and return
+        var weekNumber = 0;
+
+        // Loop over the terms. If the start date of the event falls inside of the term,
+        // use that term to calculate the week number that date falls in
+        _.each(terms, function(term) {
+            var termStartDate = new Date(term.start);
+            var termEndDate = new Date(term.end);
+            date = new Date(date);
+            // If the date falls in the term, use it to calculate the week number
+            if (termStartDate <= date && termEndDate >= date) {
+                // The number of milliseconds in one week
+                var ONE_WEEK = 1000 * 60 * 60 * 24 * 7;
+                // Convert the given date to milliseconds
+                date = date.getTime();
+                // Convert the term start date to milliseconds
+                termStartDate = termStartDate.getTime();
+                // Calculate the difference in milliseconds
+                var dateDifference = Math.abs(date - termStartDate);
+                // Convert back to weeks
+                weekNumber = Math.floor(dateDifference / ONE_WEEK) + 1;
+            }
+        });
+
+        return weekNumber;
     };
 
     /**

--- a/shared/gh/api/gh.api.util.js
+++ b/shared/gh/api/gh.api.util.js
@@ -96,7 +96,13 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
         }
 
         // TODO: add the week number when the custom configuration is in place
-        var weekNumber = 'W' + getWeekInTerm(startDate);
+        // var weekNumber = 'W' + getWeekInTerm(startDate);
+        var weekNumber = getWeekInTerm(startDate);
+        if (weekNumber === 0) {
+            weekNumber = 'OT';
+        } else {
+            weekNumber = 'W' + weekNumber;
+        }
 
         // Retrieve the day
         var weekDay = moment(endDate).utc().format('E');
@@ -332,8 +338,7 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
      * keys being the term label and values the Array of events associated to that term
      *
      * @param  {Event[]}    events    The Array of events to split up into terms
-     *
-     * @return {Object}        Object representing the split up terms and events
+     * @return {Object}               Object representing the split up terms and events
      */
     var splitEventsByTerm = exports.splitEventsByTerm = function(events) {
         // Get the configuration

--- a/shared/gh/js/controller/gh.admin-batch-edit.js
+++ b/shared/gh/js/controller/gh.admin-batch-edit.js
@@ -159,15 +159,18 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
      * @private
      */
     var handleStickyHeader = function() {
-        // Get the top of the window and the top of the header's position
-        var windowTop = $(window).scrollTop();
-        var headerTop = $('#gh-sticky-header-anchor').offset().top;
-        // If the window is scrolled further down than the header was originally
-        // positioned, make the header sticky
-        if (windowTop > headerTop) {
-            $('#gh-batch-edit-container').addClass('gh-sticky-header');
-        } else {
-            $('#gh-batch-edit-container').removeClass('gh-sticky-header');
+        // Only attempt to handle scrolling when the batch edit is being used
+        if ($('#gh-batch-edit-view').is(':visible')) {
+            // Get the top of the window and the top of the header's position
+            var windowTop = $(window).scrollTop();
+            var headerTop = $('#gh-sticky-header-anchor').offset().top;
+            // If the window is scrolled further down than the header was originally
+            // positioned, make the header sticky
+            if (windowTop > headerTop) {
+                $('#gh-batch-edit-container').addClass('gh-sticky-header');
+            } else {
+                $('#gh-batch-edit-container').removeClass('gh-sticky-header');
+            }
         }
     };
 

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -1,4 +1,4 @@
-<div class="gh-main-view">
+<div id="gh-batch-edit-view" class="gh-main-view">
     <div id="gh-toolbar-container">
         <div class="gh-toolbar gh-toolbar-primary">
             <div id="gh-calendar-toolbar-views" class="gh-toolbar-views pull-left">

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -85,6 +85,33 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
     // Test the 'generateDisplayDate' functionality
     QUnit.test('generateDisplayDate', function(assert) {
+        // Mock a configuration object to test with
+        require('gh.core').config = {
+            "terms": {
+                "2014": [
+                    {
+                        "name": "michaelmas",
+                        "label": "Michaelmas",
+                        "start": "2014-10-07T00:00:00.000Z",
+                        "end": "2014-12-04T00:00:00.000Z"
+                    },
+                    {
+                        "name": "lent",
+                        "label": "Lent",
+                        "start": "2015-01-13T00:00:00.000Z",
+                        "end": "2015-03-13T00:00:00.000Z"
+                    },
+                    {
+                        "name": "easter",
+                        "label": "Easter",
+                        "start": "2015-04-21T00:00:00.000Z",
+                        "end": "2015-06-12T00:00:00.000Z"
+                    }
+                ]
+            },
+            'academicYear': 2014
+        };
+
         var startDate = '2015-02-18T10:00:00.000Z';
         var endDate = '2015-02-18T17:30:00.000Z';
 
@@ -119,11 +146,11 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         }, 'Verify that a valid end date needs to be provided');
 
         // Verify that all the cases are covered
-        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T17:30:00.000Z'), 'W? · Wed 10am-5:30pm');
-        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T16:00:00.000Z', '2015-02-18T17:30:00.000Z'), 'W? · Wed 4-5:30pm');
-        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T11:30:00.000Z'), 'W? · Wed 10-11:30am');
-        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T11:00:00.000Z'), 'W? · Wed 10:30-11am');
-        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T13:30:00.000Z'), 'W? · Wed 10:30am-1:30pm');
+        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T17:30:00.000Z'), 'W6 · Wed 10am-5:30pm');
+        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T16:00:00.000Z', '2015-02-18T17:30:00.000Z'), 'W6 · Wed 4-5:30pm');
+        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T11:30:00.000Z'), 'W6 · Wed 10-11:30am');
+        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T11:00:00.000Z'), 'W6 · Wed 10:30-11am');
+        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T13:30:00.000Z'), 'W6 · Wed 10:30am-1:30pm');
     });
 
     // Test the 'dateDisplay' functionality

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -16,6 +16,33 @@
 require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     module('Util API');
 
+    // Mock a configuration object to test with
+    require('gh.core').config = {
+        "terms": {
+            "2014": [
+                {
+                    "name": "michaelmas",
+                    "label": "Michaelmas",
+                    "start": "2014-10-07T00:00:00.000Z",
+                    "end": "2014-12-04T00:00:00.000Z"
+                },
+                {
+                    "name": "lent",
+                    "label": "Lent",
+                    "start": "2015-01-13T00:00:00.000Z",
+                    "end": "2015-03-13T00:00:00.000Z"
+                },
+                {
+                    "name": "easter",
+                    "label": "Easter",
+                    "start": "2015-04-21T00:00:00.000Z",
+                    "end": "2015-06-12T00:00:00.000Z"
+                }
+            ]
+        },
+        'academicYear': 2014
+    };
+
 
     ////////////////
     //  CALENDAR  //
@@ -85,33 +112,6 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
     // Test the 'generateDisplayDate' functionality
     QUnit.test('generateDisplayDate', function(assert) {
-        // Mock a configuration object to test with
-        require('gh.core').config = {
-            "terms": {
-                "2014": [
-                    {
-                        "name": "michaelmas",
-                        "label": "Michaelmas",
-                        "start": "2014-10-07T00:00:00.000Z",
-                        "end": "2014-12-04T00:00:00.000Z"
-                    },
-                    {
-                        "name": "lent",
-                        "label": "Lent",
-                        "start": "2015-01-13T00:00:00.000Z",
-                        "end": "2015-03-13T00:00:00.000Z"
-                    },
-                    {
-                        "name": "easter",
-                        "label": "Easter",
-                        "start": "2015-04-21T00:00:00.000Z",
-                        "end": "2015-06-12T00:00:00.000Z"
-                    }
-                ]
-            },
-            'academicYear': 2014
-        };
-
         var startDate = '2015-02-18T10:00:00.000Z';
         var endDate = '2015-02-18T17:30:00.000Z';
 
@@ -336,33 +336,6 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     // Test the 'splitEventsByTerm' functionality
     QUnit.test('splitEventsByTerm', function(assert) {
         expect(4);
-
-        // Mock a configuration object to test with
-        require('gh.core').config = {
-            "terms": {
-                "2014": [
-                    {
-                        "name": "michaelmas",
-                        "label": "Michaelmas",
-                        "start": "2014-10-07T00:00:00.000Z",
-                        "end": "2014-12-04T00:00:00.000Z"
-                    },
-                    {
-                        "name": "lent",
-                        "label": "Lent",
-                        "start": "2015-01-13T00:00:00.000Z",
-                        "end": "2015-03-13T00:00:00.000Z"
-                    },
-                    {
-                        "name": "easter",
-                        "label": "Easter",
-                        "start": "2015-04-21T00:00:00.000Z",
-                        "end": "2015-06-12T00:00:00.000Z"
-                    }
-                ]
-            },
-            'academicYear': 2014
-        };
 
         // Mock an Array of events to test with
         var events = {

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -151,6 +151,7 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T11:30:00.000Z'), 'W6 · Wed 10-11:30am');
         assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T11:00:00.000Z'), 'W6 · Wed 10:30-11am');
         assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T13:30:00.000Z'), 'W6 · Wed 10:30am-1:30pm');
+        assert.strictEqual(gh.api.utilAPI.generateDisplayDate('2015-01-01T10:30:00.000Z', '2015-01-01T13:30:00.000Z'), 'OT · Thu 10:30am-1:30pm');
     });
 
     // Test the 'dateDisplay' functionality


### PR DESCRIPTION
As we now have the necessary configuration in place to do this, we should calculate the week in the term of the date that was chosen for an event.

I think, ideally, we should create a utility function that takes in 2 parameters `date` and `term`. Date is a string that parses into a valid date and term is the term object coming from the configuration. The utility function would calculate which week the date is in and return a Number (not a callback).

![screen shot 2015-02-04 at 11 49 45](https://cloud.githubusercontent.com/assets/218391/6039920/010e2d72-ac64-11e4-8926-77da701e22ac.png)
