### PR TITLE
Date issue when adding a new event

### DIFF
--- a/shared/gh/js/controller/gh.admin-batch-edit.js
+++ b/shared/gh/js/controller/gh.admin-batch-edit.js
@@ -675,7 +675,7 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
      */
     var batchEditDate = function(ev, trigger) {
         // Add an `active` class to the updated row to indicate that changes where made
-        $(trigger).parent().addClass('active');
+        $(trigger).parent().addClass('active gh-new-event-row');
         // Show the save button
         toggleSubmit();
     };

--- a/shared/gh/js/controller/gh.datepicker.js
+++ b/shared/gh/js/controller/gh.datepicker.js
@@ -208,8 +208,7 @@ define(['gh.core', 'moment', 'clickover', 'jquery-datepicker'], function(gh, mom
                 'onShown': function() {
 
                     // Cache the trigger
-                    var eventId = $(trigger).closest('tr').attr('data-eventid');
-                    $trigger = $(trigger).closest('tr[data-eventid="' + eventId + '"]').find('td.gh-event-date');
+                    $trigger = $(trigger).closest('tr .gh-event-date');
 
                     renderDatePicker();
                     setCalendarDate();


### PR DESCRIPTION
When adding a new event and editing the date the following error pops up:

```java
Uncaught Error: A valid date should be providedgh.api.util.js:180 
exports.fixDateToGMTgh.datepicker.js:147 
setCalendarDategh.datepicker.js:215 
_.defer.$trigger.clickover.onShownbootstrapx-clickover.js:105 
$.extend.clickeryrequire-jquery.js:2532 
jQuery.extend.proxy.proxyrequire-jquery.js:6450 
jQuery.event.dispatchrequire-jquery.js:6136 
jQuery.event.add.elemData.handlerequire-jquery.js:6365 
jQuery.event.triggerrequire-jquery.js:6916 
(anonymous function)require-jquery.js:2394 
jQuery.extend.eachrequire-jquery.js:2159 
jQuery.fn.jQuery.eachrequire-jquery.js:6915 
jQuery.fn.extend.triggergh.datepicker.js:221 
(anonymous function)lodash.js:5495 (anonymous function)
```