### PR TITLE
Implement 'cancel' in batch edit

### DIFF
--- a/shared/gh/js/controller/gh.admin-batch-edit.js
+++ b/shared/gh/js/controller/gh.admin-batch-edit.js
@@ -756,8 +756,9 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
         $('body').on('click', '.gh-new-event', addNewEventRow);
         $('body').on('click', '.gh-event-delete', deleteEvent);
 
-        // Batch edit form submission
+        // Batch edit form submission and cancel
         $('body').on('click', '#gh-batch-edit-submit', submitBatchEdit);
+        $('body').on('click', '#gh-batch-edit-cancel', loadSeriesEvents);
 
         // Batch edit header functionality
         $('body').on('keyup', '#gh-batch-edit-title', batchEditTitle);

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -97,6 +97,6 @@
     <div class="gh-batch-edit-actions-container" style="display: none;">
         <p id="gh-batch-edit-change-summary" class="pull-left"></p>
         <button type="button" id="gh-batch-edit-submit" class="btn btn-default pull-right">Save</button>
-        <button type="button" class="btn btn-link pull-right" data-dismiss="modal">Cancel</button>
+        <button type="button" id="gh-batch-edit-cancel" class="btn btn-link pull-right">Cancel</button>
     </div>
 </div>


### PR DESCRIPTION
When cancelling in batch edit, the state should be reset to what it was initially. This might be easily achievable by leveraging the hashchange logic.