### PR TITLE
Display the application name in the title

### DIFF
--- a/apps/timetable/tests/header.js
+++ b/apps/timetable/tests/header.js
@@ -23,7 +23,9 @@ casper.test.begin('Student - Component - Header', function(test) {
         casper.waitForSelector('#gh-right-container #gh-header', function() {
             test.assertExists('#gh-left-container #gh-header-logo img', 'Verify that the header hero has the Cambridge University logo');
             test.assertExists('#gh-right-container #gh-header h1', 'Verify that the header has a header h1');
-            test.assertSelectorHasText('#gh-right-container #gh-header h1', 'My timetable', 'Verify that the header has the text \'My timetable\'');
+            test.assertEval(function() {
+                return require('gh.core').data.me.app.displayName === $('#gh-right-container #gh-header h1').text();
+            }, 'Verify that the header has the correct display name of the app');
             test.assertExists('#gh-right-container #gh-header #gh-signin-form', 'Verify that the header has a login form');
         });
     };

--- a/apps/timetable/ui/index.html
+++ b/apps/timetable/ui/index.html
@@ -68,7 +68,7 @@
                     </button>
                 </form>
             <% } %>
-            <h1>My timetable</h1>
+            <h1><%- gh.data.me.app.displayName %></h1>
         </script>
 
         <script id="gh-modal-template" type="text/template">


### PR DESCRIPTION
The application name (configured in the global admin panel) should be displayed in the application's header and browser title, instead of 'My timetable'.

![screen shot 2015-01-20 at 14 59 21](https://cloud.githubusercontent.com/assets/2194396/5819360/162c368c-a0b5-11e4-99a5-5fa502509c50.png)
