### PR TITLE
Event type comes without icon

### DIFF
--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -563,7 +563,7 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
                     'end': $('.gh-event-date', $eventContainer).attr('data-end'),
                     'location': $('.gh-event-location', $eventContainer).text(),
                     // 'group': '',
-                    'notes': $('.gh-event-type', $eventContainer).text(),
+                    'notes': $('.gh-event-type', $eventContainer).attr('data-type'),
                     'organisers': $('.gh-event-organisers', $eventContainer).text(),
                     'start': $('.gh-event-date', $eventContainer).attr('data-start')
                 };
@@ -580,7 +580,7 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
                     'end': $('.gh-event-date', $eventContainer).attr('data-end'),
                     'location': $('.gh-event-location', $eventContainer).text(),
                     // 'group': '',
-                    'notes': $('.gh-event-type', $eventContainer).text(),
+                    'notes': $('.gh-event-type', $eventContainer).attr('data-type'),
                     'organisers': $('.gh-event-organisers', $eventContainer).text(),
                     'start': $('.gh-event-date', $eventContainer).attr('data-start')
                 };


### PR DESCRIPTION
The event type sometimes comes without icon.

Steps to reproduce:
- Edit an existing event by changing its title and press `ENTER` to persist the change
- Save the changes
- Reload the page

![screen shot 2015-02-06 at 09 03 01](https://cloud.githubusercontent.com/assets/2194396/6076727/100eda52-addf-11e4-8cb2-ba1d1127e2ea.png)
