### PR TITLE
Remove datepicker popover title

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -672,6 +672,10 @@ tbody tr:last-child > td.fc-widget-content {
     width: 350px;
 }
 
+.popover .popover-title {
+    display: none;
+}
+
 .popover .popover-content {
     margin: 12px 10px;
 }


### PR DESCRIPTION
The title ("Click to edit...") in the datepicker popover window should be removed.

![screen shot 2015-02-05 at 17 29 24](https://cloud.githubusercontent.com/assets/2194396/6065362/b610b192-ad5c-11e4-9307-12c3d7984f35.png)
