### PR TITLE
Vertically align batch edit label

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -321,6 +321,11 @@
     width: 100%;
 }
 
+#gh-batch-edit-header .gh-batch-edit-header-description {
+    display: table-cell;
+    vertical-align: middle;
+}
+
 #gh-batch-edit-term-container {
     margin: 0 30px 30px;
 }


### PR DESCRIPTION
The batch edit label should be vertically aligned with the text inputs.

![screen shot 2015-02-09 at 13 20 21](https://cloud.githubusercontent.com/assets/2194396/6107018/77ef88b6-b05e-11e4-86a1-444ed043cb57.png)
