### PR TITLE
Use the title of the event series to pre-populate new events

### DIFF
--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -119,11 +119,11 @@ define(['lodash', 'moment', 'gh.api.util', 'gh.api.config'], function(_, moment,
                     'eventObj': {
                         'tempId': utilAPI.generateRandomString(), // The actual ID hasn't been generated yet
                         'isNew': true, // Used in the template to know this one needs special handling
-                        'displayName': '',
+                        'displayName': $('.gh-jeditable-series-title').text(),
                         'end': moment(endDate).utc().format(),
                         'location': '',
                         'notes': 'Lecture',
-                        'organisers': 'organiser',
+                        'organisers': null,
                         'start': moment(startDate).utc().format()
                     }
                 });

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -40,11 +40,11 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
         eventObj.ev = data && data.eventObj ? data.eventObj : {
             'tempId': utilAPI.generateRandomString(), // The actual ID hasn't been generated yet
             'isNew': true, // Used in the template to know this one needs special handling
-            'displayName': '',
+            'displayName': $('.gh-jeditable-series-title').text(),
             'end': moment(new Date()).add(1, 'hours').utc().format(),
             'location': '',
             'notes': 'Lecture',
-            'organisers': 'organiser',
+            'organisers': null,
             'start': moment(new Date()).utc().format()
         };
         eventObj['utilAPI'] = utilAPI;
@@ -53,6 +53,8 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
         $eventContainer.append(utilAPI.renderTemplate($('#gh-batch-edit-event-row-template'), eventObj));
         // Enable JEditable on the row
         setUpJEditable();
+        // Show the save button
+        toggleSubmit();
     };
 
     /**
@@ -614,10 +616,9 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
                     'location': $('.gh-event-location', $eventContainer).text(),
                     // 'group': '',
                     'notes': $('.gh-event-type', $eventContainer).attr('data-type'),
-                    'organisers': $('.gh-event-organisers', $eventContainer).text(),
+                    'organisers': $('.gh-event-organisers', $eventContainer).text() || null,
                     'start': $('.gh-event-date', $eventContainer).attr('data-start')
                 };
-                updatedEventObjs.push(updatedEventObj);
             });
 
             // Loop over each new event in the term and create the event object
@@ -631,7 +632,7 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
                     'location': $('.gh-event-location', $eventContainer).text(),
                     // 'group': '',
                     'notes': $('.gh-event-type', $eventContainer).attr('data-type'),
-                    'organisers': $('.gh-event-organisers', $eventContainer).text(),
+                    'organisers': $('.gh-event-organisers', $eventContainer).text() || null,
                     'start': $('.gh-event-date', $eventContainer).attr('data-start')
                 };
                 newEventObjs.push(newEventObj);

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -619,6 +619,7 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
                     'organisers': $('.gh-event-organisers', $eventContainer).text() || null,
                     'start': $('.gh-event-date', $eventContainer).attr('data-start')
                 };
+                updatedEventObjs.push(updatedEventObj);
             });
 
             // Loop over each new event in the term and create the event object

--- a/shared/gh/partials/admin-batch-edit-event-row.html
+++ b/shared/gh/partials/admin-batch-edit-event-row.html
@@ -1,7 +1,7 @@
 <% if (ev && !ev.isNew) { %>
 <tr data-eventid="<%= ev.id %>">
 <% } else { %>
-<tr data-tempid="<%= ev.tempId %>">
+<tr data-tempid="<%= ev.tempId %>" class="active gh-new-event-row">
 <% } %>
     <td class="col-xs-1">
         <div class="checkbox">


### PR DESCRIPTION
![screen shot 2015-02-10 at 10 22 20](https://cloud.githubusercontent.com/assets/218391/6125515/b4e01e1a-b10e-11e4-8922-185d475401b8.png)

The title of an event series should be used to prepopulate the displayname field for a new event row.