### PR TITLE
Refinements to date for a new event

### DIFF
--- a/shared/gh/js/controllers/gh.api.util.js
+++ b/shared/gh/js/controllers/gh.api.util.js
@@ -163,8 +163,8 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
     /**
      * Get the Date of the first day of the specified term
      *
-     * @param  {String}    termName    The name of the term to get the Date of the first day for
-     * @return {Date}                  The Date of the first day of the term
+     * @param  {String}    termName    The name of the term to get the date of the first day for
+     * @return {Date}                  The date of the first day of the term
      */
     var getFirstDayOfTerm = exports.getFirstDayOfTerm = function(termName) {
         if (!_.isString(termName)) {
@@ -175,19 +175,16 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
         var config = require('gh.core').config;
         // Get the correct terms associated to the current application
         var terms = config.terms[config.academicYear];
-        // Variable used to assign the Date of the first day of the term to
-        var startDate = null;
-
-        // Loop over the terms
-        _.each(terms, function(term) {
+        // Find the date of the first day of the term
+        var term =_.find(terms, function(term) {
             if (term.name === termName) {
                 // Parse the start date into the variable to return
-                startDate = new Date(term.start);
+                return term;
             }
         });
 
         // Return the first day's date
-        return startDate;
+        return new Date(term.start);
     };
 
     /**

--- a/shared/gh/js/controllers/gh.api.util.js
+++ b/shared/gh/js/controllers/gh.api.util.js
@@ -177,6 +177,7 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
         var terms = config.terms[config.academicYear];
         // Find the term to get the first day's date for
         var term =_.find(terms, function(term) {
+            /* istanbul ignore else */
             if (term.name === termName) {
                 // Return the term
                 return term;

--- a/shared/gh/js/controllers/gh.api.util.js
+++ b/shared/gh/js/controllers/gh.api.util.js
@@ -175,10 +175,10 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
         var config = require('gh.core').config;
         // Get the correct terms associated to the current application
         var terms = config.terms[config.academicYear];
-        // Find the date of the first day of the term
+        // Find the term to get the first day's date for
         var term =_.find(terms, function(term) {
             if (term.name === termName) {
-                // Parse the start date into the variable to return
+                // Return the term
                 return term;
             }
         });

--- a/shared/gh/js/controllers/gh.api.util.js
+++ b/shared/gh/js/controllers/gh.api.util.js
@@ -161,6 +161,36 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
     };
 
     /**
+     * Get the Date of the first day of the specified term
+     *
+     * @param  {String}    termName    The name of the term to get the Date of the first day for
+     * @return {Date}                  The Date of the first day of the term
+     */
+    var getFirstDayOfTerm = exports.getFirstDayOfTerm = function(termName) {
+        if (!_.isString(termName)) {
+            throw new Error('A valid term name should be provided');
+        }
+
+        // Get the configuration
+        var config = require('gh.core').config;
+        // Get the correct terms associated to the current application
+        var terms = config.terms[config.academicYear];
+        // Variable used to assign the Date of the first day of the term to
+        var startDate = null;
+
+        // Loop over the terms
+        _.each(terms, function(term) {
+            if (term.name === termName) {
+                // Parse the start date into the variable to return
+                startDate = new Date(term.start);
+            }
+        });
+
+        // Return the first day's date
+        return startDate;
+    };
+
+    /**
      * Get a date by specifying the term it's in, the week number it's in and the day of the week it is
      *
      * @param  {String}    termName      The name of the term to look for the date

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -36,16 +36,18 @@ define(['gh.api.event', 'gh.api.groups', 'gh.api.series', 'gh.api.util', 'gh.adm
      */
     var addNewEventRow = function(ev, data) {
         var $eventContainer = data && data.eventContainer ? $(data.eventContainer) : $(this).closest('thead').next('tbody');
+        var termName = $eventContainer.closest('.gh-batch-edit-events-container').data('term');
+        var termStart = utilAPI.getFirstDayOfTerm(termName);
         var eventObj = {'ev': null};
         eventObj.ev = data && data.eventObj ? data.eventObj : {
             'tempId': utilAPI.generateRandomString(), // The actual ID hasn't been generated yet
             'isNew': true, // Used in the template to know this one needs special handling
             'displayName': $('.gh-jeditable-series-title').text(),
-            'end': moment(new Date()).add(1, 'hours').utc().format(),
+            'end': moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 14, 0, 0, 0])).utc().format(),
             'location': '',
             'notes': 'Lecture',
-            'organisers': null,
-            'start': moment(new Date()).utc().format()
+            'organisers': 'organiser',
+            'start': moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 13, 0, 0, 0])).utc().format()
         };
         eventObj['utilAPI'] = utilAPI;
 

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -166,6 +166,20 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         assert.strictEqual(gh.api.utilAPI.getWeeksInTerm(require('gh.core').config.terms['2014'][0]), 9, 'Verify that the correct number of weeks is returned');
     });
 
+    // Test the 'getFirstDayOfTerm' functionality
+    QUnit.test('getFirstDayOfTerm', function(assert) {
+        // Verify that a valid term name needs to be provided
+        assert.throws(function() {
+            gh.api.utilAPI.getFirstDayOfTerm(null);
+        }, 'Verify that a valid term name needs to be provided');
+
+        // Use the first day of Michaelmas to test with
+        var testDate = new Date('2014-10-07T00:00:00.000Z');
+        assert.strictEqual(gh.api.utilAPI.getFirstDayOfTerm('michaelmas').getDay(), testDate.getDay(), 'Verify that the correct day is returned');
+        assert.strictEqual(gh.api.utilAPI.getFirstDayOfTerm('michaelmas').getMonth(), testDate.getMonth(), 'Verify that the correct month is returned');
+        assert.strictEqual(gh.api.utilAPI.getFirstDayOfTerm('michaelmas').getFullYear(), testDate.getFullYear(), 'Verify that the correct year is returned');
+    });
+
     // Test the 'getDateByWeekAndDay' functionality
     QUnit.test('getDateByWeekAndDay', function(assert) {
         // Verify that a valid term name needs to be provided
@@ -186,8 +200,8 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         // Verify that the correct date is returned
         var testDate = new Date('Tue Oct 21 2014 01:00:00 GMT+0100 (BST)');
         assert.strictEqual(gh.api.utilAPI.getDateByWeekAndDay('michaelmas', 2, 2).getDay(), testDate.getDay(), 'Verify that the correct day is returned');
-        assert.strictEqual(gh.api.utilAPI.getDateByWeekAndDay('michaelmas', 2, 2).getFullYear(), testDate.getFullYear(), 'Verify that the correct year is returned');
         assert.strictEqual(gh.api.utilAPI.getDateByWeekAndDay('michaelmas', 2, 2).getMonth(), testDate.getMonth(), 'Verify that the correct month is returned');
+        assert.strictEqual(gh.api.utilAPI.getDateByWeekAndDay('michaelmas', 2, 2).getFullYear(), testDate.getFullYear(), 'Verify that the correct year is returned');
     });
 
     // Test the 'dateDisplay' functionality


### PR DESCRIPTION
A new event should get as a date the first day of the term it's being added to. We can probably fix the hours:minutes to 1PM - 2PM until design gives us a better default.