### PR TITLE
Chronologically display out of term events

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -479,22 +479,12 @@
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container {
-    margin-top: 10px;
-    margin-bottom: 40px;
+    margin-bottom: 30px;
+    margin-top: 50px;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container:first-child.gh-ot td {
     border-top: none;
-}
-
-#gh-batch-edit-term-container .gh-batch-edit-events-container:not(.gh-ot) + .gh-ot {
-    border-top-width: 2px;
-    border-top-style: solid;
-}
-
-#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot {
-    margin-bottom: 0;
-    margin-top: 0;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container:last-child {
@@ -513,6 +503,28 @@
     text-overflow: ellipsis;
     vertical-align: middle;
     white-space: nowrap;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot {
+    margin-bottom: -20px;
+    margin-top: 0;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot thead {
+    visibility: hidden;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot thead tr th {
+    border-bottom-width: 0 !important;
+    padding-bottom: 0;
+    padding-top: 0;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot thead button,
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot thead label {
+    height: 1px;
+    overflow: hidden;
+    visibility: hidden;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td:first-child {

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -480,11 +480,7 @@
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container {
     margin-bottom: 30px;
-    margin-top: 50px;
-}
-
-#gh-batch-edit-term-container .gh-batch-edit-events-container:first-child.gh-ot td {
-    border-top: none;
+    margin-top: 60px;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container:last-child {

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -448,8 +448,8 @@
 }
 
 #gh-batch-edit-container #gh-batch-edit-time-picker::after {
-    content: '';
     clear: both;
+    content: '';
     display: block;
 }
 
@@ -479,7 +479,22 @@
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container {
-    margin-bottom: 30px;
+    margin-top: 10px;
+    margin-bottom: 40px;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container:first-child.gh-ot td {
+    border-top: none;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container:not(.gh-ot) + .gh-ot {
+    border-top-width: 2px;
+    border-top-style: solid;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot {
+    margin-bottom: 0;
+    margin-top: 0;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container:last-child {

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -275,6 +275,15 @@
     background-color: #92308A;
 }
 
+/* Terms */
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot tr {
+    background-color: #F7F7F7;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container:not(.gh-ot) + .gh-ot {
+    border-top-color: #DDD;
+}
+
 /* Calendar icon */
 .gh-event-calendar-icon {
     border-color: #888;

--- a/apps/timetable/admin/ui/js/index.js
+++ b/apps/timetable/admin/ui/js/index.js
@@ -184,6 +184,9 @@ define(['gh.core', 'gh.admin-constants', 'gh.admin-listview', 'gh.admin-batch-ed
         data.eventsByTerm = gh.api.utilAPI.splitEventsByTerm(data.events);
         // Delete the events object as it's been parsed into a different object
         delete data.events;
+        // Order the events and split up the out of term events
+        data.eventsByTerm = gh.api.utilAPI.orderEventsByTerm(data.eventsByTerm);
+        // Render the batch edit template
         gh.api.utilAPI.renderTemplate($('#gh-batch-edit-template'), {
             'gh': gh,
             'data': data

--- a/shared/gh/js/controllers/gh.api.util.js
+++ b/shared/gh/js/controllers/gh.api.util.js
@@ -437,6 +437,47 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
     };
 
     /**
+     * Order the terms and split up the out of term events
+     *
+     * @param  {terms}     terms    The terms that should be reordered
+     * @return {Object}             Object containing the reordered terms and events
+     */
+    var orderEventsByTerm = exports.orderEventsByTerm = function(terms) {
+        if (!_.isObject(terms)) {
+            throw new Error('An invalid value for terms has been provided');
+        }
+
+        // Create a temporary array for the terms
+        var _terms = [];
+        _.each(terms, function(term, name) {
+            if (name !== 'OT') {
+                _terms.push({
+                    'name': name,
+                    'start': moment(term.start).utc().format(),
+                    'end': moment(term.end).utc().format(),
+                    'events': term.events
+                });
+            }
+        });
+
+        // Create a term for every out of term event
+        /* istanbul ignore else */
+        if (terms['OT']) {
+            _.each(terms['OT'].events, function(event) {
+                _terms.push({
+                    'name': 'OT',
+                    'start': moment(event.start).utc().format(),
+                    'end': moment(event.end).utc().format(),
+                    'events': [event]
+                });
+            });
+        }
+
+        // Order the terms chronologically
+        return _.sortBy(_terms, function(term) { return convertISODatetoUnixDate(term.start); });
+    };
+
+    /**
      * Split up a given Array of events into separate Arrays per term. Returns an object with
      * keys being the term label and values the Array of events associated to that term
      *
@@ -444,6 +485,10 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
      * @return {Object}               Object representing the split up terms and events
      */
     var splitEventsByTerm = exports.splitEventsByTerm = function(events) {
+        if (!_.isObject(events)) {
+            throw new Error('An invalid value for events has been provided');
+        }
+
         // Get the configuration
         var config = require('gh.core').config;
         // Get the correct terms associated to the current application
@@ -459,11 +504,16 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
             term.start = new Date(term.start);
             term.end = new Date(term.end);
             // Add an Array to the object to return with the term label as the key
-            eventsByTerm[term.label] = [];
+            eventsByTerm[term.label] = {
+                'start': term.start,
+                'end': term.end,
+                'events': []
+            };
         });
 
         // Loop over the array of events to triage them
         _.each(events.results, function(ev) {
+            var outOfTerm = true;
             // Convert start date into proper date for comparison
             var evStart = new Date(ev.start);
             // Loop over the terms and check whether the event start date
@@ -471,10 +521,21 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
             // it into the term's Array
             _.each(terms, function(term) {
                 if (evStart >= term.start && evStart <= term.end) {
+                    outOfTerm = false;
                     // The event takes place in this term, push it into the Array
-                    eventsByTerm[term.label].push(ev);
+                    eventsByTerm[term.label]['events'].push(ev);
                 }
             });
+            // Add the out of terms to a separate array
+            if (outOfTerm) {
+                /* istanbul ignore else */
+                if (!eventsByTerm['OT']) {
+                    eventsByTerm['OT'] = {
+                        'events': []
+                    };
+                }
+                eventsByTerm['OT']['events'].push(ev);
+            }
         });
 
         // Return the resulting object

--- a/shared/gh/js/controllers/gh.api.util.js
+++ b/shared/gh/js/controllers/gh.api.util.js
@@ -437,7 +437,52 @@ define(['exports', 'moment', 'bootstrap-notify'], function(exports, moment) {
     };
 
     /**
-     * Order the terms and split up the out of term events
+     * Put the terms and their events into an chronologically ordered array.
+     *
+     *  *   Instead of using the following object in our view, where all the
+     *  *   out of term events are grouped into a single object;
+     *  *
+     *  *   {
+     *  *       'Michaelmas': {
+     *  *           'events': [Object, Object, Object]
+     *  *       },
+     *  *       'Lent': {
+     *  *           'events': [Object]
+     *  *       },
+     *  *       'Easter': {
+     *  *           'events': [Object, Object]
+     *  *       },
+     *  *       'OT': {
+     *  *           'events': [Object, Object]
+     *  *       },
+     *  *
+     *  *   }
+     *  *
+     *  *   We want to have an array where all the terms and events
+     *  *   are ordered chronologically;
+     *  *
+     *  *   [
+     *  *       {
+     *  *           'name'  : 'OT'
+     *  *           'events': [Object]
+     *  *       },
+     *  *       {
+     *  *           'name'  : 'Michaelmas'
+     *  *           'events': [Object, Object, Object]
+     *  *       },
+     *  *       {
+     *  *           'name'  : 'OT'
+     *  *           'events': [Object]
+     *  *       },
+     *  *       {
+     *  *           'name'  : 'Lent'
+     *  *           'events': [Object]
+     *  *       },
+     *  *       {
+     *  *           'name'  : 'Easter'
+     *  *           'events': [Object, Object]
+     *  *       }
+     *  *   ]
      *
      * @param  {terms}     terms    The terms that should be reordered
      * @return {Object}             Object containing the reordered terms and events

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -64,15 +64,16 @@
     </div>
 
     <div id="gh-batch-edit-term-container">
-        <% _.each(data.eventsByTerm, function(term, name) { %>
-            <div class="gh-batch-edit-events-container" data-term="<%- name.toLowerCase().replace(/\ /g, '') %>">
+        <% _.each(data.eventsByTerm, function(term) { %>
+            <div class="gh-batch-edit-events-container <% if (term.name == 'OT') { %>gh-ot<% } %>" data-term="<%- term.name.toLowerCase().replace(/\ /g, '') %>" data-start="<%- term.start %>" data-end="<%- term.end %>">
                 <table class="table">
                     <thead>
+                        <% if (term.name !== 'OT') { %>
                         <tr>
                             <th class="col-xs-1" colspan="6">
                                 <div class="checkbox">
                                     <label>
-                                        <input type="checkbox" class="gh-select-all"> <%- name %>
+                                        <input type="checkbox" class="gh-select-all"> <%- term.name %>
                                     </label>
                                 </div>
                             </th>
@@ -80,9 +81,10 @@
                                 <button type="button" class="btn btn-default pull-right gh-btn-secondary gh-new-event"><i class="fa fa-plus-square"></i> Add event</button>
                             </th>
                         </tr>
+                        <% } %>
                     </thead>
                     <tbody>
-                    <% _.each(term, function(ev) { %>
+                    <% _.each(term.events, function(ev) { %>
                         <%= _.partial('admin-batch-edit-event-row', {
                             'ev': ev,
                             'gh': gh,

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -68,7 +68,6 @@
             <div class="gh-batch-edit-events-container <% if (term.name == 'OT') { %>gh-ot<% } %>" data-term="<%- term.name.toLowerCase().replace(/\ /g, '') %>" data-start="<%- term.start %>" data-end="<%- term.end %>">
                 <table class="table">
                     <thead>
-                        <% if (term.name !== 'OT') { %>
                         <tr>
                             <th class="col-xs-1" colspan="6">
                                 <div class="checkbox">
@@ -81,7 +80,6 @@
                                 <button type="button" class="btn btn-default pull-right gh-btn-secondary gh-new-event"><i class="fa fa-plus-square"></i> Add event</button>
                             </th>
                         </tr>
-                        <% } %>
                     </thead>
                     <tbody>
                     <% _.each(term.events, function(ev) { %>

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -384,9 +384,71 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         assert.equal(2, numWeeks);
     });
 
+    // Test the 'orderEventsByTerm' functionality
+    QUnit.test('orderEventsByTerm', function(assert) {
+        expect(8);
+
+        // Verify that an error is thrown when no events were provided
+        assert.throws(function() {
+            gh.api.utilAPI.orderEventsByTerm();
+        }, 'Verify that an error is thrown when no terms were provided');
+
+        // Verify that an error is thrown when an invalid value for events was provided
+        assert.throws(function() {
+            gh.api.utilAPI.orderEventsByTerm('invalid_value');
+        }, 'Verify that an error is thrown when an invalid value for events was provided');
+
+        // Split the events by term
+        var eventsByTerm = gh.api.utilAPI.splitEventsByTerm({
+            "results": [
+                { // OT after Easter
+                    "end": "2015-08-30T14:00:00.000Z",
+                    "start": "2015-08-30T13:00:00.000Z"
+                },
+                { // OT before Michaelmas
+                    "end": "2014-01-01T14:00:00.000Z",
+                    "start": "2014-01-01T13:00:00.000Z"
+                },
+                { // Michaelmas
+                    "end": "2014-10-20T14:00:00.000Z",
+                    "start": "2014-10-20T13:00:00.000Z"
+                },
+                { // Lent
+                    "end": "2015-01-30T11:00:00.000Z",
+                    "start": "2015-01-30T10:00:00.000Z"
+                },
+                { // Easter
+                    "end": "2015-04-30T14:00:00.000Z",
+                    "start": "2015-04-30T13:00:00.000Z"
+                }
+            ]
+        });
+
+        // Order the events
+        var events = gh.api.utilAPI.orderEventsByTerm(eventsByTerm);
+
+        // Verify that the events are returned in a correct order
+        assert.strictEqual(events.length, 5, 'Verify that the events are returned in a correct order');
+        assert.strictEqual(events[0].name, 'OT');
+        assert.strictEqual(events[1].name, 'Michaelmas');
+        assert.strictEqual(events[2].name, 'Lent');
+        assert.strictEqual(events[3].name, 'Easter');
+        assert.strictEqual(events[4].name, 'OT');
+    });
+
     // Test the 'splitEventsByTerm' functionality
     QUnit.test('splitEventsByTerm', function(assert) {
-        expect(4);
+        expect(6);
+
+        // Verify that an error is thrown when no events were provided
+        assert.throws(function() {
+            gh.api.utilAPI.splitEventsByTerm();
+        }, 'Verify that an error is thrown when no events were provided');
+
+        // Verify that an error is thrown when an invalid value for events was provided
+        assert.throws(function() {
+            gh.api.utilAPI.splitEventsByTerm('invalid_value');
+        }, 'Verify that an error is thrown when an invalid value for events was provided');
 
         // Mock an Array of events to test with
         var events = {
@@ -411,9 +473,9 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
         // Verify that the returning events were correctly split by term
         assert.ok(eventsByTerm, 'Verify that events can be successfully split by term');
-        assert.equal(eventsByTerm['Michaelmas'].length, 1, 'Verify that 1 event was triaged into Michaelmas');
-        assert.equal(eventsByTerm['Lent'].length, 1, 'Verify that 1 event was triaged into Lent');
-        assert.equal(eventsByTerm['Easter'].length, 1, 'Verify that 1 event was triaged into Easter');
+        assert.equal(eventsByTerm['Michaelmas'].events.length, 1, 'Verify that 1 event was triaged into Michaelmas');
+        assert.equal(eventsByTerm['Lent'].events.length, 1, 'Verify that 1 event was triaged into Lent');
+        assert.equal(eventsByTerm['Easter'].events.length, 1, 'Verify that 1 event was triaged into Easter');
     });
 
 


### PR DESCRIPTION
The **out of term** events should be displayed in a chronologically way, rather than displaying them into one block before or after the *in-term* events. For 2014-2015 we should have something like:

|  |
|:-----------:|
| Out of term (< 07/10) |
|  **Michaelmas** |
| Out of term (> 5/12 & < 13/01) |
|     **Lent**    |
| Out of term (> 13/03 & < 21/04) |
|    **Easter**   |
| Out of term (> 12/06) |