### PR TITLE
Update selection when deselecting week in batch date edit

### DIFF
--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -310,14 +310,14 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
         if ($(this).is(':checked')) {
             // Add the class
             $(this).closest('.checkbox').addClass('gh-batch-edit-date-picker-selected');
-            // Add all events to the associated week
-            addAnotherDay();
         } else {
             // Remove the class
             $(this).closest('.checkbox').removeClass('gh-batch-edit-date-picker-selected');
             // Remove all events associated to the week
             removeEventsInWeek(parseInt($(this).val(), 10));
         }
+        // Add all events to the associated week
+        addAnotherDay();
         // Get the weeks that are in use by the selection
         var weeksInUse = $('#gh-batch-edit-date-picker input:checked').length;
         // Update the weeks in use label


### PR DESCRIPTION
When selecting a week in the batch date edit header, the selected terms update to be consistent. When deselecting a week, this doesn’t happen yet.