### PR TITLE
The visibility modal is shown behind the ‘Time/dates’ button in the batch date edit header

### DIFF
--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -190,6 +190,10 @@ label {
 /* MODALS */
 /**********/
 
+.modal {
+    z-index: 10000;
+}
+
 .modal-header,
 .modal-body {
     padding: 25px;


### PR DESCRIPTION
The visibility modal is shown behind the ‘Time/dates’ button in the batch date edit header. To reproduce, open up the batch date edit header and then open the visibility modal.