### PR TITLE
Missing end-time in event-popover

### DIFF
--- a/shared/gh/partials/event-popover.html
+++ b/shared/gh/partials/event-popover.html
@@ -1,6 +1,6 @@
 <div class="popover fade" role="tooltip" data-id="<%- data.id %>">
     <h3 class="gh-popover-title"><%- data.displayName %></h3>
-    <p class="gh-popover-time"><%- moment.utc(data.start).format('dddd h:mma') %></p>
+    <p class="gh-popover-time"><%- moment.utc(data.start).format('dddd h:mma') %> - <%- moment.utc(data.end).format('h:mma') %></p>
     <p class="gh-popover-location"><%- data.location %></p>
     <p class="gh-popover-organiser">
         <%- _.chain(data.organisers).map(function(organiser) { return organiser.displayName; }).value().join(', ') %>


### PR DESCRIPTION
It looks like we're missing and end time in the event popover.

![screen shot 2015-02-23 at 10 24 51](https://cloud.githubusercontent.com/assets/2194396/6326535/abc1e85e-bb4a-11e4-9f8d-be53f0859446.png)
