### PR TITLE
Catch error when no academic year is set

### DIFF
--- a/apps/admin/ui/js/index.js
+++ b/apps/admin/ui/js/index.js
@@ -451,6 +451,7 @@ define(['gh.core', 'chosen', 'jquery-bbq'], function(gh) {
     var addBinding = function() {
         $('body').on('change', 'input[type="checkbox"]', updateCheckboxValue);
         $('body').on('click', '#gh-tenants-apps-form .gh-update-app', submitTenantForm);
+        $('body').on('click', '#gh-tenants-apps-form .gh-create-app', submitTenantForm);
         $('body').on('click', '#gh-tenants-apps-form .gh-launch-app', launchApp);
         $('body').on('click', '#gh-administrators-form button', submitAdministratorForm);
         $('body').on('submit', '.gh-configuration-form', submitConfigurationForm);

--- a/apps/admin/ui/js/index.js
+++ b/apps/admin/ui/js/index.js
@@ -452,6 +452,7 @@ define(['gh.core', 'chosen', 'jquery-bbq'], function(gh) {
         $('body').on('change', 'input[type="checkbox"]', updateCheckboxValue);
         $('body').on('click', '#gh-tenants-apps-form .gh-update-app', submitTenantForm);
         $('body').on('click', '#gh-tenants-apps-form .gh-create-app', submitTenantForm);
+        $('body').on('click', '#gh-tenants-apps-form .gh-create-tenant', submitTenantForm);
         $('body').on('click', '#gh-tenants-apps-form .gh-launch-app', launchApp);
         $('body').on('click', '#gh-administrators-form button', submitAdministratorForm);
         $('body').on('submit', '.gh-configuration-form', submitConfigurationForm);

--- a/shared/gh/js/controllers/gh.api.js
+++ b/shared/gh/js/controllers/gh.api.js
@@ -92,6 +92,12 @@ define(['gh.utils', 'gh.api.admin', 'gh.api.app', 'gh.api.authentication', 'gh.a
                         throw new Error('The configuration for the app could not be retrieved');
                     }
 
+                    // Show a message to the user informing them that the app hasn't been properly configured
+                    // if the academicYear hasn't been set
+                    if (!config.terms[config.academicYear]) {
+                        utils.notification('App not configured', 'The application has not yet been properly configured for an academic year.', 'error', null, true);
+                    }
+
                     // Cache the config on the global gh.data object
                     gh.config = config;
 

--- a/shared/gh/js/utils/gh.utils.js
+++ b/shared/gh/js/utils/gh.utils.js
@@ -255,14 +255,15 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
      * This function is mostly just a wrapper around jQuery.bootstrap.notify.js and supports all of the options documented
      * at https://github.com/goodybag/bootstrap-notify.
      *
-     * @param  {String}    [title]    The notification title
-     * @param  {String}    message    The notification message that will be shown underneath the title
-     * @param  {String}    [type]     The notification type. The supported types are `success`, `error` and `info`, as defined in http://getbootstrap.com/components/#alerts. By default, the `success` type will be used
-     * @param  {String}    [id]       Unique identifier for the notification, in case a notification can be triggered twice due to some reason. If a second notification with the same id is triggered it will be ignored
-     * @throws {Error}                Error thrown when no message has been provided
-     * @return {Boolean}              Returns true when the notification has been shown
+     * @param  {String}    [title]     The notification title
+     * @param  {String}    message     The notification message that will be shown underneath the title
+     * @param  {String}    [type]      The notification type. The supported types are `success`, `error` and `info`, as defined in http://getbootstrap.com/components/#alerts. By default, the `success` type will be used
+     * @param  {String}    [id]        Unique identifier for the notification, in case a notification can be triggered twice due to some reason. If a second notification with the same id is triggered it will be ignored
+     * @param  {String}    [sticky]    Whether or not the notification should be sticky. Defaults to `false`
+     * @throws {Error}                 Error thrown when no message has been provided
+     * @return {Boolean}               Returns true when the notification has been shown
      */
-    var notification = exports.notification = function(title, message, type, id) {
+    var notification = exports.notification = function(title, message, type, id, sticky) {
         if (!message) {
             throw new Error('A valid notification message should be provided');
         }
@@ -288,7 +289,7 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
         // Show the actual notification
         $notificationContainer.notify({
             'fadeOut': {
-                'enabled': true,
+                'enabled': sticky ? false : true,
                 'delay': 5000
             },
             'type': type,


### PR DESCRIPTION
The error that is thrown when no academic year is set should be catched in the UI. The error also prevents the calendar from being loaded.