### PR TITLE
Input fields need padding

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -339,6 +339,11 @@
     width: 100%;
 }
 
+#gh-batch-edit-header input[type="text"] {
+    padding-left: 6px;
+    padding-right: 6px;
+}
+
 #gh-batch-edit-header > div > * {
     height: 39px;
     width: 100%;


### PR DESCRIPTION
The input fields in the batch edit header need proper padding (see design)

![screen shot 2015-02-23 at 10 22 43](https://cloud.githubusercontent.com/assets/2194396/6326518/7a1b46c4-bb4a-11e4-89d4-a3da75e79824.png)
