### PR TITLE
Add 'skip to navigation' links at the top of the page

### DIFF
--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -24,6 +24,7 @@
         <link rel='stylesheet' href="/shared/gh/css/gh.print.css" media="print">
     </head>
     <body data-isadminui="true">
+        <a href="#gh-subheader" class="sr-only">Skip to navigation</a>
         <div id="gh-page-container">
             <div id="gh-left-container">
                 <div id="gh-meta-container">

--- a/apps/timetable/ui/index.html
+++ b/apps/timetable/ui/index.html
@@ -20,6 +20,7 @@
         <link rel='stylesheet' href="/shared/gh/css/gh.print.css" media="print">
     </head>
     <body>
+        <a href="#gh-subheader" class="sr-only">Skip to navigation</a>
         <div id="gh-page-container">
             <div id="gh-left-container">
                 <div id="gh-meta-container">


### PR DESCRIPTION
Add 'skip to navigation' links at the top of the page to improve accessibility.