### PR TITLE
Wrong week number is displayed

### DIFF
--- a/shared/gh/js/constants/gh.constants.js
+++ b/shared/gh/js/constants/gh.constants.js
@@ -31,6 +31,7 @@ define(['exports'], function(exports) {
 
         // Keep track of number of milliseconds in a day, week and month for use in the calendar
         'PERIODS': {
+            'hour': 1000 * 60 * 60,
             'day': 1000 * 60 * 60 * 24,
             'week': 1000 * 60 * 60 * 24 * 7,
             'month': 1000 * 60 * 60 * 24 * 7 * 30

--- a/shared/gh/js/constants/gh.constants.js
+++ b/shared/gh/js/constants/gh.constants.js
@@ -31,7 +31,6 @@ define(['exports'], function(exports) {
 
         // Keep track of number of milliseconds in a day, week and month for use in the calendar
         'PERIODS': {
-            'hour': 1000 * 60 * 60,
             'day': 1000 * 60 * 60 * 24,
             'week': 1000 * 60 * 60 * 24 * 7,
             'month': 1000 * 60 * 60 * 24 * 7 * 30

--- a/shared/gh/js/utils/gh.utils.time.js
+++ b/shared/gh/js/utils/gh.utils.time.js
@@ -169,8 +169,8 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
             return 0;
         }
 
-        // Get the start date of the corresponding term
-        var startDate = convertISODatetoUnixDate(moment(currentTerm.start).utc().format('YYYY-MM-DD'));
+        // Get the start date of the corresponding term (and add one hour to catch the summer time difference)
+        var startDate = convertISODatetoUnixDate(moment(currentTerm.start).add({'hours': 1}).utc().format('YYYY-MM-DD'));
 
         // Retrieve the day number of the first day of the term
         var dayNumber = parseInt(moment(startDate).format('E'), 10);
@@ -186,7 +186,7 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
         // week in that term. If it can't be retrieved the date is out of term and 0 should
         // be returned
         var weekNumber = 0;
-        if (getTerm(date, true)) {
+        if (currentTerm) {
             weekNumber = Math.ceil(((date - startDate) / constants.time.PERIODS['week']) - (dayOffset)) + 1;
         }
 

--- a/shared/gh/js/utils/gh.utils.time.js
+++ b/shared/gh/js/utils/gh.utils.time.js
@@ -150,10 +150,11 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
      *  *
      *  *   week = (weeks - offset) + 1
      *
-     * @param  {Number}    date     The date where the academic week number needs to be returned for
-     * @return {Number}             The academic week number
+     * @param  {Number}     date          The date where the academic week number needs to be returned for
+     * @param  {Boolean}    usePrecise    Whether of not an offset should be used. (Default: false)
+     * @return {Number}                   The academic week number
      */
-    var getAcademicWeekNumber = exports.getAcademicWeekNumber = function(date) {
+    var getAcademicWeekNumber = exports.getAcademicWeekNumber = function(date, usePrecise) {
         if (!_.isNumber(date)) {
             throw new Error('A valid date should be provided');
         }
@@ -163,8 +164,11 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
         // Get the correct terms associated to the current application
         var terms = config.terms[config.academicYear];
 
+        // The default value for 'usePrecise' is false
+        usePrecise = usePrecise || false;
+
         // Retrieve the corresponding term of the specified date
-        var currentTerm = getTerm(date);
+        var currentTerm = getTerm(date, usePrecise);
         if (!currentTerm) {
             return 0;
         }

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -175,9 +175,9 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-12T10:30:00.000Z'));
         assert.strictEqual(weekNumber, 1, 'Verify that a valid week number is returned when specifying an out-of-term date');
 
-        // Verify that a valid week number is returned when specifying an out-of-term date that leans close to the start of a term, using precise
+        // Verify that a valid week number is returned when specifying an out-of-term date that leans close to the start of a term, using precise calculation
         weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-12T10:30:00.000Z'), true);
-        assert.strictEqual(weekNumber, 0, 'Verify that a valid week number is returned when specifying an out-of-term date');
+        assert.strictEqual(weekNumber, 0, 'Verify that a valid week number is returned when specifying an out-of-term date, using precise calculation');
 
         // Verify that a valid week number is returned when specifying an in-term date
         weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-14T10:30:00.000Z'));

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -173,6 +173,10 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
         // Verify that a valid week number is returned when specifying an out-of-term date that leans close to the start of a term
         weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-12T10:30:00.000Z'));
+        assert.strictEqual(weekNumber, 1, 'Verify that a valid week number is returned when specifying an out-of-term date');
+
+        // Verify that a valid week number is returned when specifying an out-of-term date that leans close to the start of a term, using precise
+        weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-12T10:30:00.000Z'), true);
         assert.strictEqual(weekNumber, 0, 'Verify that a valid week number is returned when specifying an out-of-term date');
 
         // Verify that a valid week number is returned when specifying an in-term date


### PR DESCRIPTION
The wrong academic week number seems to be displayed in the student UI.

Steps to reproduce:
- Navigate to a term using the term navigator => 'Week 2' should be 'Week 1'
- Go backward and forward one week => 'Outside term' should be 'Week 1'

![screen shot 2015-02-23 at 10 08 33](https://cloud.githubusercontent.com/assets/2194396/6326414/4aedb23e-bb49-11e4-856d-975a414fba4f.png)
