### PR TITLE
Fade out success and failure colorisation after update in batch edit

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -517,6 +517,13 @@
     white-space: nowrap;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr.danger.gh-fade td,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr.success.gh-fade td {
+    -webkit-transition: background-color 2s;
+       -moz-transition: background-color 2s;
+            transition: background-color 2s;
+}
+
 #gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot {
     margin-bottom: -20px;
     margin-top: 0;

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -284,6 +284,11 @@
     border-top-color: #DDD;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr.danger.gh-fade td,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr.success.gh-fade td {
+    background-color: #FFF !important;
+}
+
 /* Calendar icon */
 .gh-event-calendar-icon {
     border-color: #888;

--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -88,7 +88,7 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
             var dateWeek = gh.utils.getAcademicWeekNumber(startDate);
             // If the event takes place in the week that needs to be removed, delete it
             if (dateWeek === weekNumber) {
-                $row.addClass('gh-event-deleted').find('.gh-event-delete').click();
+                $row.addClass('gh-event-deleted').find('.gh-event-delete button').click();
             }
         });
     };

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -574,8 +574,10 @@ define(['gh.constants', 'gh.utils', 'gh.api.event', 'gh.api.groups', 'gh.api.ser
                         }
                 }
 
-                // Fade the row colours
-                fadeRowColour($row);
+                // Fade the row colours if there were no errors
+                if (!hasError) {
+                    fadeRowColour($row);
+                }
             });
         };
 
@@ -627,8 +629,10 @@ define(['gh.constants', 'gh.utils', 'gh.api.event', 'gh.api.groups', 'gh.api.ser
                     $row.data('eventid', data.id).attr('data-eventid', data.id).removeClass('gh-new-event-row');
                 }
 
-                // Fade the row colours
-                fadeRowColour($row);
+                // Fade the row colours if there were no errors
+                if (!hasError) {
+                    fadeRowColour($row);
+                }
 
                 // If we're done, execute the callback, otherwise call the function again with
                 // the next event to create

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -21,6 +21,26 @@ define(['gh.constants', 'gh.utils', 'gh.api.event', 'gh.api.groups', 'gh.api.ser
     ///////////////
 
     /**
+     * Fade the colourisation of a row over 2 seconds and remove the `gh-fade` class
+     * after the animation completes
+     *
+     * @param  {Object|String}    $row    jQuery object or selector of the row to fade
+     * @private
+     */
+    var fadeRowColour = function($row) {
+        // Make sure we're dealing with a jQuery object
+        $row = $($row);
+        // Set a timeout of 2 seconds before fading out the row colour
+        setTimeout(function() {
+            $row.addClass('gh-fade');
+            // Set a timeout of 2 seconds before removing the `gh-fade` animation class
+            setTimeout(function() {
+                $row.removeClass('danger active success gh-fade');
+            }, 2000);
+        }, 2000);
+    };
+
+    /**
      * Enable editing of the series title
      *
      * @private
@@ -511,16 +531,18 @@ define(['gh.constants', 'gh.utils', 'gh.api.event', 'gh.api.groups', 'gh.api.ser
                     hasError = true;
                 }
 
+                var $row = $('.gh-batch-edit-events-container tbody tr[data-eventid="' + updatedEvent.id + '"]');
+
                 if (updatedEvent.organisers) {
                     // Update the event organisers
                     eventAPI.updateEventOrganisers(updatedEvent.id, updatedEvent.organisers, function(orgErr, data) {
                         if (orgErr) {
                             hasError = true;
                             // Mark the row so it's visually obvious that the update failed
-                            $('.gh-batch-edit-events-container tbody tr[data-eventid="' + updatedEvent.id + '"]').addClass('danger');
+                            $row.addClass('danger');
                         } else {
                             // Mark the row so it's visually obvious that the update was successful
-                            $('.gh-batch-edit-events-container tbody tr[data-eventid="' + updatedEvent.id + '"]').removeClass('danger active').addClass('success');
+                            $row.removeClass('danger active').addClass('success');
                         }
 
                         // If we're done, execute the callback, otherwise call the function again with
@@ -536,10 +558,10 @@ define(['gh.constants', 'gh.utils', 'gh.api.event', 'gh.api.groups', 'gh.api.ser
                         if (evErr) {
                             hasError = true;
                             // Mark the row so it's visually obvious that the update failed
-                            $('.gh-batch-edit-events-container tbody tr[data-eventid="' + updatedEvent.id + '"]').addClass('danger');
+                            $row.addClass('danger');
                         } else {
                             // Mark the row so it's visually obvious that the update was successful
-                            $('.gh-batch-edit-events-container tbody tr[data-eventid="' + updatedEvent.id + '"]').removeClass('danger active').addClass('success');
+                            $row.removeClass('danger active').addClass('success');
                         }
 
                         // If we're done, execute the callback, otherwise call the function again with
@@ -551,6 +573,9 @@ define(['gh.constants', 'gh.utils', 'gh.api.event', 'gh.api.groups', 'gh.api.ser
                             submitEventUpdate(updatedEventObjs[done], _callback);
                         }
                 }
+
+                // Fade the row colours
+                fadeRowColour($row);
             });
         };
 
@@ -589,18 +614,21 @@ define(['gh.constants', 'gh.utils', 'gh.api.event', 'gh.api.groups', 'gh.api.ser
             // Get the ID of the series this event is added to
             var seriesId = parseInt($.bbq.getState()['series'], 10);
             eventAPI.createEvent(newEvent.displayName, newEvent.start, newEvent.end, null, null, newEvent.location, newEvent.notes, newEvent.organiserOther, newEvent.organiserUsers, seriesId, function(evErr, data) {
+                var $row = $('.gh-batch-edit-events-container tbody tr[data-tempid="' + newEvent.tempId + '"]');
                 if (evErr) {
                     hasError = true;
                     // Mark the row so it's visually obvious that the creation failed
-                    $('.gh-batch-edit-events-container tbody tr[data-tempid="' + newEvent.tempId + '"]').addClass('danger');
+                    $row.addClass('danger');
                 } else {
-                    var $row = $('.gh-batch-edit-events-container tbody tr[data-tempid="' + newEvent.tempId + '"]');
                     // Mark the row so it's visually obvious that the creation was successful
                     $row.removeClass('danger active').addClass('success');
                     // Replace the temporary ID with the real one
                     $row.data('tempid', null).removeAttr('data-tempid');
                     $row.data('eventid', data.id).attr('data-eventid', data.id).removeClass('gh-new-event-row');
                 }
+
+                // Fade the row colours
+                fadeRowColour($row);
 
                 // If we're done, execute the callback, otherwise call the function again with
                 // the next event to create
@@ -804,13 +832,15 @@ define(['gh.constants', 'gh.utils', 'gh.api.event', 'gh.api.groups', 'gh.api.ser
             createNewEvents(newEventObjs, function(newErr) {
                 // Delete events
                 deleteEvents(eventsToDelete, function(deleteErr) {
+                    // Re-enable all elements in the UI
+                    disableEnableAll(false);
+
                     if (updateErr || newErr || deleteErr) {
+                        // Show an error notification
                         return utils.notification('Events not updated.', 'Not all events could be successfully updated.', 'error');
                     }
                     // Hide the save button
                     toggleSubmit();
-                    // Re-enable all elements in the UI
-                    disableEnableAll(false);
                     // Show a success notification to the user
                     return utils.notification('Events updated.', 'The events where successfully updated.');
                 });


### PR DESCRIPTION
The success en failure colorisation should fade out after a while when updates have been persisted.