### PR TITLE
Polish tripos / part selector on the student UI

### DIFF
--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -48,6 +48,11 @@
     background-color: #92308A;
 }
 
+.chosen-container .chosen-single,
+.chosen-container .chosen-drop {
+    border-color: #FFF !important;
+}
+
 
 /***********/
 /* POPOVER */

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -620,9 +620,16 @@ tbody tr:last-child > td.fc-widget-content {
     height: 45px !important;
 }
 
+.chosen-container .chosen-single,
+.chosen-container .chosen-drop {
+    -webkit-box-shadow: 0 3px 5px rgba(0, 0, 0, 0.30);
+       -moz-box-shadow: 0 3px 5px rgba(0, 0, 0, 0.30);
+            box-shadow: 0 3px 5px rgba(0, 0, 0, 0.30);
+}
+
 .chosen-container .chosen-single span,
 .chosen-container .chosen-single b {
-    margin-top: 9px;
+    margin-top: 11px;
 }
 
 .chosen-container .chosen-single b {
@@ -635,7 +642,7 @@ tbody tr:last-child > td.fc-widget-content {
 }
 
 .chosen-container .chosen-search input {
-    padding: 6px 12px !important;
+    padding: 5px 20px 4px 7px !important;
     font-size: 14px !important;
     line-height: 1.42857143 !important;
     background-image: none !important;
@@ -651,13 +658,14 @@ tbody tr:last-child > td.fc-widget-content {
 }
 
 .chosen-container .chosen-results {
-    margin: 0 8px 8px 0;
+    margin: 0 8px 0 0;
     max-height: 320px;
     padding: 0 0 0 8px;
 }
 
 .chosen-container .chosen-results li {
-    padding: 10px 5px;
+    font-weight: 400;
+    padding: 10px 8px;
 }
 
 .chosen-container .chosen-results li.highlighted {

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -630,7 +630,7 @@ tbody tr:last-child > td.fc-widget-content {
 
 .chosen-container .chosen-single span,
 .chosen-container .chosen-single b {
-    margin-top: 11px;
+    margin-top: 9px;
 }
 
 .chosen-container .chosen-single b {
@@ -661,7 +661,7 @@ tbody tr:last-child > td.fc-widget-content {
 .chosen-container .chosen-results {
     margin: 0 8px 0 0;
     max-height: 320px;
-    padding: 0 0 0 8px;
+    padding: 0 0 5px 8px;
 }
 
 .chosen-container .chosen-results li {

--- a/shared/gh/js/views/gh.subheader.js
+++ b/shared/gh/js/views/gh.subheader.js
@@ -78,9 +78,11 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
 
         // Initialise the Chosen plugin on the part picker
         $('#gh-subheader-part').chosen({
-            'no_results_text': 'No matches for',
-            'disable_search_threshold': 10
+            'disable_search': true
         }).on('change', setUpModules);
+
+        // Chosen has a bug where search sometimes isn't disabled properly
+        $('#gh_subheader_part_chosen .chosen-search').hide();
     };
 
     /**
@@ -115,6 +117,9 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
         $('#gh-subheader-tripos').chosen({
             'no_results_text': 'No matches for'
         }).change(setUpPartPicker);
+
+        // Set the default placeholder text
+        $('#gh_subheader_tripos_chosen .chosen-search input').attr('placeholder', 'Search triposes');
     };
 
     /**


### PR DESCRIPTION
Here is a changeset I did in browser:

* [x] Add placeholder text to search input: "Search triposes"
* [x] Search input padding: 5px 20px 4px 7px !important
* [x] On "chosen-results" ul element: 
    * [x] bring down the bottom margin: 0 8px 0 
    * [x] align up padding with search input field text: 5px 0 0 12px
* [ ] ~~on group list items (bold):~~
    * [ ] ~~add fa-right-caret to the front of the group~~ 
    * [ ] ~~add 2px right margin to the caret icon~~
* [x] increase font weight of list elements to 400
* [x] make border white for "chosen-single chosen-default" a element
* [x] make border white fror autocomplete container
* [x] tighten up the shadows: 0 3px 5px rgba(0, 0, 0, 0.30)
* [ ] ~~Collapse group list items with right caret, toggling open and closed states~~
* [x] EDIT: Vertically center dropdown placeholder texts (.chosen-container .chosen-single span, .chosen-container .chosen-single b) with 11px top margin

to make it look like this:

![my_timetable](https://cloud.githubusercontent.com/assets/117483/6395428/f8a56af6-bdcf-11e4-9886-2b2a47794352.png)

Apply relevant changes to part selector too.
 