### PR TITLE
Time slots need a a higher width

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -677,11 +677,22 @@
     line-height: 16px;
 }
 
+.gh-event-description {
+    max-width: 220px !important;
+    min-width: 175px !important;
+    text-overflow: ellipsis;
+}
+
+.gh-event-date {
+    max-width: 250px !important;
+    min-width: 210px !important;
+}
+
 .gh-event-display-date {
     line-height: 20px;
     margin-left: 30px;
     margin-top: -10px;
-    max-width: 150px;
+    max-width: 170px;
     text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
The time slots in the admin batch edit interface need a higher minimum width.

![screen shot 2015-02-23 at 10 13 02](https://cloud.githubusercontent.com/assets/2194396/6326452/a755f6a8-bb49-11e4-9b58-5528202a6d6f.png)
