### PR TITLE
Tweak student UI calendar display

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -111,7 +111,7 @@
 /* Secondary toolbar */
 #gh-toolbar-container .gh-toolbar-secondary {
     font-weight: 600;
-    padding-top: 40px;
+    padding-top: 28px;
     opacity: 1;
     position: relative;
     -webkit-transition: opacity .2s;
@@ -129,6 +129,7 @@
 
 #gh-toolbar-container .gh-toolbar-secondary .btn-default.gh-btn-tertiary {
     height: auto;
+    margin-bottom: 2px;
 }
 
 #gh-toolbar-container .gh-toolbar-secondary .btn-default.gh-btn-tertiary i {
@@ -155,8 +156,9 @@
 
 .gh-toolbar-label {
     display: inline-block;
+    font-weight: 400;
+    min-width: 60px;
     text-align: center;
-    min-width: 100px;
 }
 
 /* Calendar (assumes weekly view and other views inherit unless otherwise specified) */
@@ -189,9 +191,13 @@
     border-bottom-style: solid !important;
     border-bottom-width: 6px;
     font-size: 16px;
-    font-weight: 600;
-    height: 50px;
+    font-weight: 400;
+    height: 40px;
     vertical-align: middle;
+}
+
+.fc-agendaDay-view .fc-row.fc-widget-header thead tr th.fc-today, .fc-agendaWeek-view .fc-row.fc-widget-header thead tr th.fc-today {
+    font-weight: 600;
 }
 
 .fc-month-view td.fc-today {

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -99,8 +99,7 @@ a,
 
 .btn-default:hover,
 .btn-default:focus,
-.btn-default:disabled,
-.btn-default#gh-btn-calendar-today {
+.btn-default:disabled {
     color: #FFF;
     background-color: #2A2A2A;
     border-color: #2A2A2A;
@@ -150,8 +149,7 @@ a,
     color: #FFF;
 }
 
-.btn-default.gh-btn-secondary.gh-btn-reverse:active,
-.btn-default#gh-btn-calendar-today:hover {
+.btn-default.gh-btn-secondary.gh-btn-reverse:active {
     background-color: #2D939C;
     border-color: #2D939C;
     color: #FFF;
@@ -176,7 +174,7 @@ a,
 .btn-default.gh-btn-tertiary:focus {
     background-color: #171717;
     border-color: #171717;
-    color: #7A7A7A;
+    color: #FFF;
 }
 
 .btn-default.gh-btn-tertiary:active {
@@ -303,12 +301,26 @@ a,
     border-bottom-color: #171717 !important;
 }
 
+.fc-agendaWeek-view .fc-row.fc-widget-header thead tr th.fc-today {
+    background-color: #E0E7E4;
+}
+
 .fc-month-view .fc-bg td.fc-today:before {
     border-top-color: #414141;
 }
 
 .fc-month-view td.fc-today {
     border-top-color: #171717 !important;
+}
+
+.fc-agendaWeek-view td.fc-today,
+.fc-month-view td.fc-today {
+    background-color: #E0E7E4 !important;
+}
+
+.fc-sat,
+.fc-sun {
+    background-color: #FFF !important;
 }
 
 .fc-slats .fc-minor td {

--- a/shared/gh/partials/calendar.html
+++ b/shared/gh/partials/calendar.html
@@ -34,7 +34,7 @@
 
             <!-- Navigate to the current day -->
             <div id="gh-calendar-toolbar-today" class="text-center">
-                <button id="gh-btn-calendar-today" class="btn btn-default">Today</button>
+                <button id="gh-btn-calendar-today" class="btn btn-default gh-btn-tertiary">Today</button>
             </div>
 
             <!-- Navigate through the terms -->


### PR DESCRIPTION
In week mode, apply all relevant to other views too:

* [x] Day top column:
    * [x] Drop font weight to 400
    * [x] Leave only weight at 600 for today @ "fc-today"
    * [x] Set background of today to #E0E7E4
    * [x] Drop <th> heigth to 40px

* [x] Make Sat and Sunday BG white
* [x] Make current day BG #E0E7E4
* [x] Make left & right chevron buttons (Week and Terms) color #fff on hover state

* [x] Toolbar:
    * [x] Vertically center the toolbar: gh-toolbar gh-toolbar-secondary > padding-top: 28px;
    * [x] Bring down the "gh-toolbar-label" min-width to 60px
    * [x] bring down the Term and week selector font to 400
    * [x] Align term and week selector copy with left right chevron button: gh-toolbar-label margin-bottom: 2px
    * [x] Make today button secondary button


![my_timetable](https://cloud.githubusercontent.com/assets/117483/6397007/d89bca3e-bdd9-11e4-9d3a-51c7849a5b6e.png)

