### PR TITLE
Adjust the tripos selection contextual help

### DIFF
--- a/apps/timetable/tests/subheader.js
+++ b/apps/timetable/tests/subheader.js
@@ -21,7 +21,7 @@ casper.test.begin('Student - Component - Subheader', function(test) {
     var verifySubHeader = function() {
         casper.waitForSelector('#gh-right-container #gh-header h1', function() {
             test.assertExists('#gh-left-container #gh-meta-container #gh-content-description', 'Verify that the subheader has a content description');
-            test.assertSelectorHasText('#gh-left-container #gh-meta-container #gh-content-description', 'Select your course and part to view available modules', 'Verify that the subheader has the correct content description');
+            test.assertSelectorHasText('#gh-left-container #gh-meta-container #gh-content-description', 'Choose a tripos & part to see available modules', 'Verify that the subheader has the correct content description');
             casper.waitForSelector('#gh-subheader #gh_subheader_tripos_chosen.chosen-container', function() {
                 test.assertExists('#gh-subheader #gh_subheader_tripos_chosen.chosen-container', 'Verify that the subheader has a tripos picker');
                 // Open the tripos picker

--- a/apps/timetable/ui/index.html
+++ b/apps/timetable/ui/index.html
@@ -27,7 +27,7 @@
                         <img src="/shared/gh/img/unilogo.png" alt="Cambridge University">
                     </a>
                     <div id="gh-content-description">
-                        <p>Select your course and part to view available modules</p>
+                        <p style="display: none;">Choose a tripos &amp; part<br/> to see available modules</p>
                     </div>
                 </div>
                 <div id="gh-modules-container"><!-- --></div>

--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -86,7 +86,7 @@ label {
 
 #gh-page-container #gh-left-container #gh-content-description p {
     margin: 0;
-    padding: 30px 39px;
+    padding: 32px 39px 30px;
 }
 
 #gh-page-container #gh-left-container #gh-meta-container {

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -72,6 +72,10 @@ a,
     color: #FFF;
 }
 
+#gh-page-container #gh-left-container #gh-content-description {
+    color: rgba(255, 255, 255, 0.6);
+}
+
 #gh-page-container #gh-left-container #gh-result-summary p {
     color: #FFF;
 }

--- a/shared/gh/errors/401.html
+++ b/shared/gh/errors/401.html
@@ -25,7 +25,7 @@
                     <img src="/shared/gh/img/unilogo.png" alt="Cambridge University">
                 </a>
                 <div id="gh-content-description">
-                    <p style="display: none;">Select your course and part to view available modules</p>
+                    <p style="display: none;">Choose a tripos &amp; part<br/> to see available modules</p>
                 </div>
             </div>
             <div id="gh-modules-container"><!-- --></div>

--- a/shared/gh/errors/404.html
+++ b/shared/gh/errors/404.html
@@ -25,7 +25,7 @@
                     <img src="/shared/gh/img/unilogo.png" alt="Cambridge University">
                 </a>
                 <div id="gh-content-description">
-                    <p style="display: none;">Select your course and part to view available modules</p>
+                    <p style="display: none;">Choose a tripos &amp; part<br/> to see available modules</p>
                 </div>
             </div>
             <div id="gh-modules-container"><!-- --></div>

--- a/shared/gh/errors/503.html
+++ b/shared/gh/errors/503.html
@@ -25,7 +25,7 @@
                     <img src="/shared/gh/img/unilogo.png" alt="Cambridge University">
                 </a>
                 <div id="gh-content-description">
-                    <p style="display: none;">Select your course and part to view available modules</p>
+                    <p style="display: none;">Choose a tripos &amp; part<br/> to see available modules</p>
                 </div>
             </div>
             <div id="gh-modules-container"><!-- --></div>

--- a/shared/gh/js/views/gh.subheader.js
+++ b/shared/gh/js/views/gh.subheader.js
@@ -146,6 +146,10 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
             $.bbq.removeState('tripos', 'part', 'module', 'series');
             // There is no state for the tripos, make sure it's reset
             setUpTriposPicker();
+            // Show the contextual help
+            if (!$('body').data('isadminui')) {
+                $('#gh-content-description p').show();
+            }
             // Resetting the tripos means destroying the part picker and hiding it
             if ($('#gh_subheader_part_chosen').length) {
                 // Destroy the field if it's been initialised previously
@@ -161,6 +165,10 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
             $('#gh-subheader-part').val(state.part);
             $('#gh-subheader-part').trigger('change', {'selected': state.part});
             $('#gh-subheader-part').trigger('chosen:updated');
+            // Hide the contextual help
+            if (!$('body').data('isadminui')) {
+                $('#gh-content-description p').hide();
+            }
 
             // Dispatch an event to update the visibility button
             $(document).trigger('gh.part.changed', {'part': state.part});
@@ -169,6 +177,10 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
             $.bbq.removeState('part', 'module', 'series');
             // Show the informational message to the user, if there is one
             gh.utils.renderTemplate($('#gh-tripos-help-template'), null, $('#gh-modules-list-container'));
+            // Show the contextual help
+            if (!$('body').data('isadminui')) {
+                $('#gh-content-description p').show();
+            }
 
             // Dispatch an event to update the visibility button
             $(document).trigger('gh.part.changed');


### PR DESCRIPTION
* [x] Adjust copy as per image below, with specific line break as shown
* [x] Add 2 px to the top margin to align it to tripos/part selector dropdowns
* [x] Bring down text opacity to rgba(255,255,255,0.6)
* [x] Interactions:
    * [x] Help text should be shown at /# state
    * [x] Once a tripos & part selection is made, the help text should be hidden

![my_timetable](https://cloud.githubusercontent.com/assets/117483/6410492/b292351a-be67-11e4-992d-02bd56dab25e.png)
