### PR TITLE
Adjust secondary link weight

### DIFF
--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -190,6 +190,10 @@ label {
     font-weight: 200;
 }
 
+.btn-default.gh-btn-secondary {
+    font-weight: 400;
+}
+
 
 /**********/
 /* MODALS */


### PR DESCRIPTION
All secondary links should use the regular weight (400) of Myriad Pro.

![my_timetable](https://cloud.githubusercontent.com/assets/117483/6412051/ce65dc88-be76-11e4-9e85-b6eb2e5cd669.png)
