### PR TITLE
Adjust padding of calendar toolbar to align with day label

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -130,8 +130,8 @@
 /* Secondary toolbar */
 #gh-toolbar-container .gh-toolbar-secondary {
     font-weight: 600;
-    padding-top: 28px;
     opacity: 1;
+    padding: 28px 20px 0;
     position: relative;
     -webkit-transition: opacity .2s;
        -moz-transition: opacity .2s;


### PR DESCRIPTION
20px padding-left to the div of class="gh-toolbar gh-toolbar-secondary" shoudl do:

![my_timetable](https://cloud.githubusercontent.com/assets/117483/6412751/ed0b25ea-be7f-11e4-9c1e-b7e9fc0dda0d.png)
