### PR TITLE
Adjust calendar subscription popout

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -365,8 +365,8 @@ tbody tr:last-child > td.fc-widget-content {
 }
 
 #gh-calendar-view #gh-export-container #gh-export-main {
-    padding: 30px;
     margin-top: 30px;
+    padding: 30px 30px 10px 40px;
     width: 370px;
 }
 
@@ -377,9 +377,15 @@ tbody tr:last-child > td.fc-widget-content {
             transition: opacity .2s;
 }
 
+#gh-calendar-view #gh-export-container #gh-export-main p#gh-export-add-description {
+    font-weight: 400;
+    margin-bottom: 20px;
+}
+
 #gh-calendar-view #gh-export-container #gh-export-main #gh-export-subscribe {
+    border: none;
     display: block;
-    padding: 15px;
+    padding: 16px 0 14px 0;
     width: 100%;
 }
 
@@ -393,21 +399,22 @@ tbody tr:last-child > td.fc-widget-content {
     font-weight: 400;
     list-style-type: decimal;
     margin-left: 18px;
+    padding-bottom: 5px;
 }
 
 #gh-calendar-view #gh-export-container #gh-export-main textarea {
-    height: 70px;
     font-family: monospace;
     font-size: 13px;
-    margin-bottom: 25px;
-    padding: 7px 12px;
+    height: 100px;
+    margin: 0 0 20px 18px;
+    padding: 5px 5px;
     resize: none;
-    width: 100%;
+    width: 280px;
 }
 
 #gh-calendar-view #gh-export-container #gh-export-main ul {
     list-style-type: circle;
-    padding: 0 0 0 25px;
+    padding: 0 0 0 33px;
 }
 
 #gh-calendar-view #gh-export-container #gh-export-main ul li {
@@ -418,9 +425,13 @@ tbody tr:last-child > td.fc-widget-content {
     margin: 0;
 }
 
+#gh-calendar-view #gh-export-container #gh-export-main ul li i {
+    font-size: 14px;
+}
+
 #gh-calendar-view #gh-export-container > #gh-export-sync-message {
     display: block;
-    padding: 20px 20px 20px 30px;
+    padding: 20px 20px 20px 40px;
     width: 400px;
 }
 
@@ -434,9 +445,8 @@ tbody tr:last-child > td.fc-widget-content {
 
 #gh-calendar-view #gh-export-container > #gh-export-sync-message small {
     display: block;
-    font-size: 14px;
+    font-size: 15px;
     overflow: auto;
-    width: 210px;
 }
 
 /* Export calendar animations */
@@ -452,6 +462,7 @@ tbody tr:last-child > td.fc-widget-content {
 #gh-calendar-view.gh-export-enabled #gh-export-container {
     opacity: 1;
     width: 400px;
+    z-index: 2;
 }
 
 #gh-calendar-view.gh-export-enabled .gh-toolbar-primary button {

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -31,17 +31,15 @@ h1, h2, h3, h4, h5 {
 }
 
 a,
-.btn-link {
+.btn-link,
+.btn-link i {
     color: #127077;
 }
 
-.btn-link i {
-    color: #171717;
-}
-
+.btn-link:hover,
 .btn-link:hover i,
 .btn-link:focus i {
-    color: #777;
+    color: #2A6496;
 }
 
 .gh-warning-text {
@@ -398,6 +396,11 @@ tbody .fc-sun {
     background-color: #FFF;
 }
 
+#gh-calendar-view #gh-export-container #gh-export-main textarea {
+    background-color: #FAFAFA;
+    border-color: #B3B3B3;
+}
+
 #gh-calendar-view #gh-export-container #gh-export-main #gh-export-subscribe {
     background-color: #07525D;
 }
@@ -406,8 +409,12 @@ tbody .fc-sun {
     background-color: #127077;
 }
 
+#gh-calendar-view #gh-export-container #gh-export-main ul li i {
+    color: rgba(61, 61, 61, 0.4);
+}
+
 #gh-calendar-view #gh-export-container > #gh-export-sync-message {
-    color: #777;
+    color: #6C6C6C;
 }
 
 /***********/

--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -322,6 +322,9 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
      */
     var toggleExportOptions = function() {
         $(this).find('i').toggleClass('fa-caret-right fa-caret-down');
+        _.defer(function() {
+            $('#gh-export-subscribe-copy').select();
+        });
     };
 
     /**

--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -322,6 +322,7 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
      */
     var toggleExportOptions = function() {
         $(this).find('i').toggleClass('fa-caret-right fa-caret-down');
+        // Pre-select the ical URL in the textarea after the call stack clears
         _.defer(function() {
             $('#gh-export-subscribe-copy').select();
         });

--- a/shared/gh/partials/calendar.html
+++ b/shared/gh/partials/calendar.html
@@ -54,16 +54,16 @@
     <% if (!data.gh.data.me.anon) { %>
         <div id="gh-export-container">
             <div id="gh-export-main">
-                <p>Add &amp; subscribe to my timetable with my default calendar app:</p>
+                <p id="gh-export-add-description">Add &amp; subscribe to your timetable<br/>with your default calendar app</p>
                 <a href="<%= 'webcal://' + window.location.hostname + '/api/users/' + data.gh.data.me.id + '/' + data.gh.data.me.calendarToken + '/calendar.ical' %>" id="gh-export-subscribe" class="btn btn-primary">Subscribe</a>
 
                 <button type="button" id="gh-export-collapsed-other-toggle" class="btn btn-link" data-toggle="collapse" data-target="#gh-export-collapsed-other" aria-expanded="false" aria-controls="gh-export-collapsed-other">
-                    <i class="fa fa-caret-right"></i>Other ways to subscribe:
+                    <i class="fa fa-caret-right"></i>Other ways to subscribe
                 </button>
                 <div class="collapse" id="gh-export-collapsed-other">
-                    <p class="gh-export-other-option">Copy the address of your timetable:</p>
+                    <p class="gh-export-other-option">Copy the address of your timetable</p>
                     <textarea id="gh-export-subscribe-copy"><%= window.location.origin + '/api/users/' + data.gh.data.me.id + '/' + data.gh.data.me.calendarToken + '/calendar.ical' %></textarea>
-                    <p class="gh-export-other-option">Follow the instructions to add &amp; subscribe with your favourite Calendar app:</p>
+                    <p class="gh-export-other-option">Follow the instructions to add &amp; subscribe with your favourite calendar app</p>
                     <ul>
                         <li><a href="https://support.google.com/calendar/answer/37100?hl=en" target="_blank" title="Google Calendar subscription instructions">Google Calendar</a> <i class="fa fa-external-link"></i></li>
                         <li><a href="https://support.office.com/en-in/article/View-and-subscribe-to-Internet-Calendars-f6248506-e144-4508-b658-c838b6067597#bm2" target="_blank" title="Microsoft Outlook subscription instructions">Microsoft Outlook</a> <i class="fa fa-external-link"></i></li>
@@ -73,7 +73,7 @@
             </div>
             <div id="gh-export-sync-message">
                 <i class="fa fa-info-circle"></i>
-                <small>Updates will be synced automatically, within ~ 8 hours after a change.</small>
+                <small>Updates will be synced automatically,<br/>within ~ 8 hours after a change.</small>
             </div>
         </div>
     <% } %>


### PR DESCRIPTION
**Base state:**
* [x] Adjust copy and line break as per image
* [x] Adjust bottom margin of first help line to 20px
* [x] Adjust font weight of first help line to 400
* [x] Adjust padding of Subscribe button to: 16px 0 14px 0 to vertically align
* [x] Remove #357ebd border color from Subscribe button
* [x] Adjust white container's padding to: 30px 30px 10px 40px
* [x] Adjust contextual (grey) info padding to: 20px 20px 20px 40px
* [x] Adjust contextual (grey) info font-size to 15px, adjust width to stay at 2 lines
* [x] Remove colons from copy
* [x] Adjust color of right caret icon in "Other ways..."  to: #127077
* [x] Adjust color of info icon to #6C6C6C

![my_timetable](https://cloud.githubusercontent.com/assets/117483/6412274/8da35f92-be79-11e4-9915-89d0f597d989.png)

**Open state:**
* [x] Adjust numbered paragraph bottom padding to 5px
* [x] Adjust URL textarea to:
```
height: 100px;
font-family: monospace;
font-size: 13px;
margin: 0 0 20px 18px;
padding: 5px 5px;
resize: none;
width: 280px;
background-color: #FAFAFA;
border-color: #B3B3B3;
```
* [x] Adjust calendar app list ul padding: 0 0 0 33px
* [x] Make external link color & font-size to: rgba(61, 61, 61, 0.4) and 14px
* [x] Remove capital C from "Calendar" and make it a midget

**Interactions:**
* [x] On opening up "Other ways..." the URL textarea should automatically receive focus and preselect

![my_timetable](https://cloud.githubusercontent.com/assets/117483/6412527/f729d81c-be7c-11e4-8a12-6facb1c6e0ce.png)



