### PR TITLE
Bug: Borrowing part selector not displaying parts

### DIFF
--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -268,7 +268,7 @@ label {
     left: 40px;
     position: fixed;
     width: 30%;
-    z-index: 9999;
+    z-index: 99999999;
 }
 
 .notifications.bottom-left > .alert {

--- a/shared/gh/js/views/gh.borrow-series.js
+++ b/shared/gh/js/views/gh.borrow-series.js
@@ -52,7 +52,9 @@ define(['gh.core', 'gh.api.orgunit'], function(gh, orgunitAPI) {
 
         // Render the results in the part picker
         gh.utils.renderTemplate($('#gh-borrow-series-part-template'), {
-            'data': parts
+            'data': {
+                'parts': parts
+            }
         }, $('#gh-borrow-series-part'));
 
         // Show the subheader part picker
@@ -66,6 +68,9 @@ define(['gh.core', 'gh.api.orgunit'], function(gh, orgunitAPI) {
             'no_results_text': 'No matches for',
             'disable_search_threshold': 10
         }).on('change', setUpModules);
+
+        // Chosen has a bug where search sometimes isn't disabled properly
+        $('#gh_borrow_series_part_chosen .chosen-search').hide();
     };
 
     /**


### PR DESCRIPTION
I there are 2 issues:
 * [x] Parts not showing up in part selector
 * [x] Part selector has search

It should show / work as the main one

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6445653/5248c2bc-c0fd-11e4-9894-70103be1eada.png)
