### PR TITLE
Admin UI: Tweak event listing display

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -393,14 +393,54 @@
     width: 100%;
 }
 
-#gh-batch-edit-header input[type="text"] {
+#gh-batch-edit-header input[type="text"],
+#gh-batch-edit-header select {
+    font-weight: 200;
     padding-left: 6px;
     padding-right: 6px;
 }
 
-#gh-batch-edit-header > div > * {
+#gh-batch-edit-header th {
+    border-bottom: none;
+}
+
+#gh-batch-edit-header .table thead tr th:nth-child(1),
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th:nth-child(1) {
+    width: 25px;
+}
+
+#gh-batch-edit-header .table thead tr th:nth-child(3),
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th:nth-child(3) {
+    width: 170px;
+}
+
+#gh-batch-edit-header .table thead tr th:nth-child(4),
+#gh-batch-edit-header .table thead tr th:nth-child(5),
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th:nth-child(4),
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th:nth-child(5) {
+    width: 150px;
+}
+
+#gh-batch-edit-header .table thead tr th:nth-child(6),
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th:nth-child(6) {
+    width: 105px;
+}
+
+#gh-batch-edit-header .table thead tr th:last-child,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th:last-child {
+    width: 50px;
+}
+
+#gh-batch-edit-header th > * {
     height: 39px;
     width: 100%;
+}
+
+#gh-batch-edit-header th:first-child {
+    font-weight: 200;
+    font-size: 13px;
+    padding: 0;
+    vertical-align: middle;
 }
 
 #gh-batch-edit-header {
@@ -408,7 +448,6 @@
 }
 
 #gh-batch-edit-header .gh-batch-edit-header-description {
-    display: table-cell;
     vertical-align: middle;
 }
 
@@ -416,17 +455,19 @@
     border-bottom-style: solid;
     border-bottom-width: 2px;
     height: 51px;
-    padding-bottom: 10px;
+    padding-bottom: 61px;
 }
 
 #gh-batch-edit-header.gh-batch-edit-time-open #gh-batch-edit-time {
     border-bottom: none !important;
     border-style: solid;
     border-width: 2px;
-    height: 51px !important;
-    padding-top: 0;
-    position: absolute;
-    right: 0;
+    bottom: -16px;
+    height: 55px !important;
+    margin-top: -53px;
+    padding-top: 10px;
+    position: relative;
+    right: 0px;
     z-index: 9999;
 }
 
@@ -444,12 +485,12 @@
 .gh-batch-edit-time-open + #gh-batch-edit-date-container {
     height: auto !important;
     opacity: 1 !important;
-    padding: 20px 50px 0 !important;
+    padding: 20px 0 0 !important;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-term-description {
     float: left;
-    width: 20%;
+    width: 150px;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-term-description h2 {
@@ -550,12 +591,16 @@
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container {
-    margin-bottom: 30px;
-    margin-top: 60px;
+    margin-bottom: 0;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container:last-child {
     margin-bottom: 100px;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table {
+    font-size: 15.3px;
+    table-layout: fixed;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th {
@@ -566,7 +611,7 @@
     cursor: pointer;
     max-width: 200px;
     overflow: hidden;
-    padding: 8px 13px;
+    padding: 6px 0px 6px 15px;
     text-overflow: ellipsis;
     vertical-align: middle;
     white-space: nowrap;
@@ -588,11 +633,11 @@
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-organisers[title] {
     overflow: hidden;
-    padding: 0;
+    padding: 6px 0px 6px 15px;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot {
-    margin-bottom: -20px;
+    margin-bottom: 10px;
     margin-top: 0;
 }
 
@@ -616,15 +661,18 @@
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td:first-child {
     cursor: auto;
     max-width: 40px;
+    padding: 0 0 0 8px;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox,
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td .checkbox {
+    font-size: 16px;
     margin: 0;
 }
 
-#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox {
-    margin-left: 5px;
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox label {
+    font-weight: 700;
+    margin-bottom: 7px;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox input,
@@ -680,11 +728,11 @@
     border-radius: 12px;
     content: attr(data-first);
     display: inline-block;
-    height: 22px;
+    height: 20px;
     margin-right: 6px;
     padding: 1px;
     text-align: center;
-    width: 22px;
+    width: 20px;
 }
 
 .gh-batch-edit-events-container .gh-event-type.gh-editing::before {
@@ -708,10 +756,6 @@
 
 .gh-event-calendar-icon .month,
 .gh-event-calendar-icon .day {
-    -webkit-font-smoothing: antialiased;
-       -moz-font-smoothing: antialiased;
-         -o-font-smoothing: antialiased;
-            font-smoothing: antialiased;
     display: block;
     font-weight: 800;
     text-align: center;
@@ -724,7 +768,8 @@
 }
 
 .gh-event-calendar-icon .day {
-    font-size: 13px;
+    font-size: 12.5px;
+    font-weight: 700;
     line-height: 16px;
 }
 
@@ -1087,6 +1132,7 @@ ul.as-selections li.as-selection-item {
 }
 
 .as-results {
+    font-weight: 200;
     position: absolute;
 }
 

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -342,6 +342,10 @@
     background-color: #FFF !important;
 }
 
+tr.info .gh-event-delete button i {
+    color: #4D4D4D;
+}
+
 /* Calendar icon */
 .gh-event-calendar-icon {
     border-color: #888;
@@ -356,6 +360,7 @@
 
 .gh-event-calendar-icon .day {
     background-color: #FFF;
+    color: #4D4D4D;
     text-shadow: 1px 1px 1px rgba(255,255,255,0.004);
 }
 

--- a/shared/gh/partials/admin-batch-edit-event-row.html
+++ b/shared/gh/partials/admin-batch-edit-event-row.html
@@ -3,15 +3,15 @@
 <% } else { %>
 <tr data-tempid="<%= ev.tempId %>" class="<% if (ev.selected) { %>info<% } %> active gh-new-event-row">
 <% } %>
-    <td class="col-xs-1">
+    <td>
         <div class="checkbox">
             <label>
                 <input type="checkbox" class="gh-select-single" title="Click to select the event" <% if (ev.selected) { %> checked="checked" <% } %>> <span class="sr-only">Select</span>
             </label>
         </div>
     </td>
-    <td class="col-xs-2 gh-jeditable-events gh-event-description" tabindex="0" title="Click to edit the event name"><%- ev.displayName %></td>
-    <td class="col-xs-2 gh-event-date" data-start="<%- ev.start %>" data-end="<%- ev.end %>" tabindex="0" title="Click to edit the event start and end times">
+    <td class="gh-jeditable-events gh-event-description" tabindex="0" title="Click to edit the event name"><%- ev.displayName %></td>
+    <td class="gh-event-date" data-start="<%- ev.start %>" data-end="<%- ev.end %>" tabindex="0" title="Click to edit the event start and end times">
         <%= _.partial('admin-edit-date-field', {
             'data': ev,
             'utils': utils
@@ -29,11 +29,11 @@
             <% } %>
         <% }); %>
     </td>
-    <td class="col-xs-2 gh-event-organisers" tabindex="0" title="Click to edit the event organisers"><%- organiserString.join(', ') %></td>
-    <td class="col-xs-2 gh-jeditable-events gh-event-location" tabindex="0" title="Click to edit the event location"><%- ev.location %></td>
-    <td class="col-xs-2 gh-jeditable-events-select gh-event-type" data-type="<%- ev.notes %>" data-first="<% if (ev.notes) { %><%- ev.notes.substr(0,1) %><% } %>" tabindex="0" title="Click to edit the event notes">
+    <td class="gh-event-organisers" tabindex="0" title="Click to edit the event organisers"><%- organiserString.join(', ') %></td>
+    <td class="gh-jeditable-events gh-event-location" tabindex="0" title="Click to edit the event location"><%- ev.location %></td>
+    <td class="gh-jeditable-events-select gh-event-type" data-type="<%- ev.notes %>" data-first="<% if (ev.notes) { %><%- ev.notes.substr(0,1) %><% } %>" tabindex="0" title="Click to edit the event notes">
     <%- ev.notes %></td>
-    <td class="col-xs-1 gh-event-delete" tabindex="0" title="Select the row and click to delete this event">
+    <td class="gh-event-delete" tabindex="0" title="Select the row and click to delete this event">
         <button type="button" class="btn btn-link"><i class="fa fa-trash"></i></button>
     </td>
 </tr>

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -35,30 +35,34 @@
                 <h1 class="gh-jeditable-series-title"><%- data.series.displayName %></h1>
 
                 <div id="gh-batch-edit-header">
-                    <div class="col-xs-1">
-                        <span class="gh-batch-edit-header-description">Batch edit:</span>
-                    </div>
-                    <div class="col-xs-2">
-                        <input type="text" id="gh-batch-edit-title" placeholder="Event titles">
-                    </div>
-                    <div class="col-xs-2">
-                        <button type="button" id="gh-batch-edit-time" class="btn btn-default pull-right" disabled><i class="fa fa-calendar"></i> Time/dates</button>
-                    </div>
-                    <div class="col-xs-2 gh-batch-event-organisers">
-                        <input type="text" id="gh-batch-edit-organisers" placeholder="Organisers">
-                    </div>
-                    <div class="col-xs-2">
-                        <input type="text" id="gh-batch-edit-location" placeholder="Locations">
-                    </div>
-                    <div class="col-xs-2">
-                        <%= _.partial('admin-batch-edit-event-type', {
-                            'data': {
-                                'id': 'gh-batch-edit-type',
-                                'types': gh.config.events.types
-                            }
-                        }) %>
-                    </div>
-                    <div class="col-xs-1"></div>
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th>Batch edit:</th>
+                                <th>
+                                    <input type="text" id="gh-batch-edit-title" placeholder="Event titles">
+                                </th>
+                                <th>
+                                    <button type="button" id="gh-batch-edit-time" class="btn btn-default pull-right" disabled><i class="fa fa-calendar"></i> Time/dates</button>
+                                </th>
+                                <th class="gh-batch-event-organisers">
+                                    <input type="text" id="gh-batch-edit-organisers" placeholder="Organisers">
+                                </th>
+                                <th>
+                                    <input type="text" id="gh-batch-edit-location" placeholder="Locations">
+                                </th>
+                                <th>
+                                    <%= _.partial('admin-batch-edit-event-type', {
+                                        'data': {
+                                            'id': 'gh-batch-edit-type',
+                                            'types': gh.config.events.types
+                                        }
+                                    }) %>
+                                </th>
+                                <th></th>
+                            </tr>
+                        </thead>
+                    </table>
                 </div>
                 <div id="gh-batch-edit-date-container"><!-- --></div>
             </div>
@@ -69,14 +73,19 @@
                         <table class="table">
                             <thead>
                                 <tr>
-                                    <th class="col-xs-1" colspan="6">
+                                    <th>
                                         <div class="checkbox">
                                             <label>
                                                 <input type="checkbox" class="gh-select-all"> <%- term.name %>
                                             </label>
                                         </div>
                                     </th>
-                                    <th class="col-xs-1">
+                                    <th></th>
+                                    <th></th>
+                                    <th></th>
+                                    <th></th>
+                                    <th></th>
+                                    <th>
                                         <button type="button" class="btn btn-default pull-right gh-btn-secondary gh-new-event"><i class="fa fa-plus-square"></i> Add event</button>
                                     </th>
                                 </tr>


### PR DESCRIPTION
* [x] Remove 60px top margin from container (gh-batch-edit-events-container)
* [x] Term labels / selectors: increase font-weight to 700, add 5px bottom margin to line up with "Add event"  
* [x] Set td padding to 6px 0px 6px 15px apart from the first element: 0 0 0 8px
* [x] Set font-size for the whole table 15.3px, but set it to 16px for the first td elements (checkboxes)
* [x] Only display trashcan icon for selected items as per #232 
* [x] Set colored type badge width and height to 20px
* [x] Calendar date icons: set font-size to 12.5px, weight to 700 and color to #4D4D4D

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6466248/192bc7c4-c1be-11e4-84a1-14210d6af766.png)

* [x] Adjust column widths based on the "add-batch-edit lecturers.pdf" proportions to fit as per character count data we have:
![screen shot 2015-03-03 at 14 58 48](https://cloud.githubusercontent.com/assets/117483/6464982/df72c3dc-c1b5-11e4-90d1-bba2bc4fd413.png)