### PR TITLE
Adjust batch edit sticky footer

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -703,7 +703,7 @@
     bottom: 0;
     border-top-width: 1px;
     border-top-style: solid;
-    padding: 20px;
+    padding: 15px 30px;
     position: fixed;
     width: -moz-calc(100% - 320px); /* Firefox */
     width: -o-calc(100% - 320px); /* Opera */
@@ -712,7 +712,12 @@
 }
 
 .gh-batch-edit-actions-container #gh-batch-edit-change-summary {
-    margin: 9px 0 0px 12px;
+    font-weight: 400;
+    margin: 9px 0 0;
+}
+
+.gh-batch-edit-actions-container #gh-batch-edit-cancel {
+    font-weight: 400;
 }
 
 .gh-batch-edit-actions-container #gh-batch-edit-submit {

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -271,14 +271,18 @@
 
 .gh-batch-edit-actions-container {
     background: #FFF;
-    border-top-color: #EEE;
+    border-top-color: #BEBEBE;
     -webkit-box-shadow: 0 0px 15px #666;
        -moz-box-shadow: 0 0px 15px #666;
             box-shadow: 0 0px 15px #666;
 }
 
 .gh-batch-edit-actions-container #gh-batch-edit-change-summary {
-    color: #999;
+    color: #6B6B6B;
+}
+
+.gh-batch-edit-actions-container #gh-batch-edit-cancel {
+    color: #171717;
 }
 
 .gh-batch-edit-events-container .gh-jeditable-form input {

--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -188,6 +188,11 @@ label {
 .btn {
     font-size: 15px;
     font-weight: 200;
+    padding: 10px 20px 8px 18px;
+}
+
+.btn-default {
+    font-weight: 700;
 }
 
 .btn-default.gh-btn-secondary {

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -106,7 +106,7 @@
 
             <div class="gh-batch-edit-actions-container" style="display: none;">
                 <p id="gh-batch-edit-change-summary" class="pull-left"></p>
-                <button type="button" id="gh-batch-edit-submit" class="btn btn-default pull-right">Save</button>
+                <button type="button" id="gh-batch-edit-submit" class="btn btn-default pull-right"><i class="fa fa-check"></i> Save</button>
                 <button type="button" id="gh-batch-edit-cancel" class="btn btn-link pull-right">Cancel</button>
             </div>
         </div>


### PR DESCRIPTION
 * [x] Set color of help text to #6B6B6B
 * [x] Set font-weight of help text to 400, and left margin to 0
 * [x] Adjust primary button as per create series ticket
 * [x] Set footer padding to 15px 30px to align up with content
 * [x] Adjust secondary Cancel link color to #171717, font-weight 400
 * [x] Add more crispness to the top border by setting color to #bebebe

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6485813/3ab16866-c27e-11e4-843b-3e92a623eeed.png)
