### PR TITLE
Adjust top margin  for modules in the module / series listing

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -576,7 +576,7 @@ tbody tr:last-child > td.fc-widget-content {
 .list-group .list-group-item .gh-list-description {
     display: table-cell;
     overflow: auto;
-    padding: 15px 5px 10px 0;
+    padding: 18px 5px 10px 0;
     width: 230px;
 }
 


### PR DESCRIPTION
 * [x] Set top margin to 18px to align with side caret
 * [x] Remove focus outline

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6485254/488eb1d6-c27a-11e4-97e1-173f714d4549.png)

