### PR TITLE
Student UI: minor tweaks

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -37,7 +37,7 @@
 /*************/
 
 #gh-right-container #gh-subheader form {
-    margin: 0;
+    margin: 0 0 0 40px;
     min-width: 960px;
     padding: 28px 0 0;
 }
@@ -725,7 +725,7 @@ tbody tr:last-child > td.fc-widget-content {
 /***********/
 
 .popover {
-    font-size: 12px;
+    font-size: 14px;
     max-width: 350px;
     width: 350px;
 }
@@ -736,6 +736,7 @@ tbody tr:last-child > td.fc-widget-content {
 
 .popover .popover-content {
     margin: 12px 10px;
+    padding: 5px 10px;
 }
 
 .popover h3 {
@@ -755,6 +756,7 @@ tbody tr:last-child > td.fc-widget-content {
     border-top-style: solid;
     border-top-width: 1px;
     display: block;
+    font-size: 14px;
     margin-top: 15px;
     padding-top: 7px;
 }

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -439,7 +439,7 @@ tbody .fc-sun {
 
 .popover small {
     border-top-color: #DDD;
-    color: #777;
+    color: #999;
 }
 
 


### PR DESCRIPTION
* [x] Add 40px left margin to tripos selector
* [x] Increase description font-size to 14px
* [x] Increase small bottom line font size to 14px, and color to  #999
* [x] Set popover-content padding to 5px 10px

![my_timetable](https://cloud.githubusercontent.com/assets/117483/6486618/fce5cf76-c283-11e4-8216-86ffefcbf367.png)
