### PR TITLE
Put in final list of event types

### DIFF
--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -312,24 +312,20 @@
     display: none;
 }
 
-.gh-batch-edit-events-container .gh-event-type[data-type="Field Trip"]::before {
-    background-color: #7D9D5C;
-}
-
-.gh-batch-edit-events-container .gh-event-type[data-type="Lab"]::before {
-    background-color: #FF944D;
-}
-
 .gh-batch-edit-events-container .gh-event-type[data-type="Lecture"]::before {
     background-color: #19A3FF;
 }
 
-.gh-batch-edit-events-container .gh-event-type[data-type="Paper"]::before {
-    background-color: #FF4719;
+.gh-batch-edit-events-container .gh-event-type[data-type="Class"]::before {
+    background-color: #FF944D;
 }
 
 .gh-batch-edit-events-container .gh-event-type[data-type="Seminar"]::before {
     background-color: #92308A;
+}
+
+.gh-batch-edit-events-container .gh-event-type[data-type="Other"]::before {
+    background-color: #FF4719;
 }
 
 /* Terms */

--- a/shared/gh/files/config.json
+++ b/shared/gh/files/config.json
@@ -1,11 +1,10 @@
 {
     "events": {
         "types": [
-            "Field Trip",
-            "Lab",
             "Lecture",
-            "Paper",
-            "Seminar"
+            "Class",
+            "Seminar",
+            "Other"
         ]
     },
     "terms":


### PR DESCRIPTION
The event type dropdown should contain the following list of event types in the following order:
* Lecture
* Class
* Seminar
* Other

All newly created events should default to Lecture type

During production data migration all other event types other than these should be re-classified as "Other"

Supporting data for this decision from the current production database, apart from checking with John:
![legacy_tt_database_entity_stats_-_google_sheets](https://cloud.githubusercontent.com/assets/117483/6485141/5fddcc1a-c279-11e4-9c3a-beec59850421.png)

