### PR TITLE
Admin UI: Adjust create series & primary buttons

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -299,12 +299,16 @@
 }
 
 #gh-new-series-form .form-group label {
-    font-weight: 200;
+    font-weight: 400;
 }
 
 #gh-new-series-form .form-group input {
+    font-size: 28px;
+    font-weight: 400;
+    height: 41px;
     margin: 0 12px;
-    width: 80%;
+    padding: 5px 10px 3px 10px;
+    width: 55%;
 }
 
 

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -215,9 +215,8 @@
 /* NEW SERIES */
 /**************/
 
-
 #gh-new-series-form .form-group label {
-    color: #8D8D8D;
+    color: #171717;
 }
 
 

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -22,6 +22,10 @@ h1, h2, h3, h4, h5 {
     color: #171717;
 }
 
+input {
+    color: #171717 !important;
+}
+
 #gh-page-container #gh-subheader h1,
 #gh-page-container #gh-subheader h2,
 #gh-page-container #gh-subheader h3,

--- a/shared/gh/js/utils/gh.utils.js
+++ b/shared/gh/js/utils/gh.utils.js
@@ -439,6 +439,13 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
     /////////////
 
     /**
+     * Refresh the state by triggering the statechange event without making modifications
+     */
+    var refreshState = exports.refreshState = function() {
+        History.Adapter.trigger(window, 'statechange');
+    };
+
+    /**
      * Add a key/value pair to the URL state
      *
      * @param {Object}    toAdd        The key of the state parameter to set

--- a/shared/gh/js/views/gh.new-series.js
+++ b/shared/gh/js/views/gh.new-series.js
@@ -16,6 +16,15 @@
 define(['gh.core', 'gh.constants', 'gh.utils', 'gh.api.orgunit', 'gh.api.series'], function(gh, constants, utils, orgunitAPI, seriesAPI) {
 
     /**
+     * Cancel the creation of a new series and return to the last state
+     *
+     * @private
+     */
+    var cancelCreateNewSeries = function() {
+        gh.utils.refreshState();
+    };
+
+    /**
      * Create a new series
      *
      * @private
@@ -106,16 +115,14 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'gh.api.orgunit', 'gh.api.series'
             });
         });
 
-        // Cancel creating a new series
-        $('body').on('click', '#gh-create-series-cancel', function() {
-            $(document).trigger('gh.admin.changeView', {'name': constants.views.EDITABLE_PARTS});
-        });
-
         // Toggle the enabled status of the submit button
         $('body').on('keyup', '#gh-series-name', toggleButton);
 
         // Create a new series
         $('body').on('submit', '#gh-new-series-form', createNewSeries);
+
+        // Cancel creating a new series
+        $('body').on('click', '#gh-create-series-cancel', cancelCreateNewSeries);
     };
 
     addBinding();

--- a/shared/gh/partials/new-series.html
+++ b/shared/gh/partials/new-series.html
@@ -1,7 +1,8 @@
 <form id="gh-new-series-form" class="form form-inline" role="form">
     <div class="form-group col-xs-12">
         <label for="gh-series-name">Series title</label>
-        <input type="text" name="series-name" class="form-control" id="gh-series-name" placeholder="Enter a name for your new series" required>
+        <input type="text" name="series-name" class="form-control" id="gh-series-name" placeholder="Enter a title for the new event series" required>
         <button type="submit" id="gh-create-series-submit" class="btn btn-default" data-groupid="<%- data.groupId %>" data-parentid="<%- data.parentId %>" data-partid="<%- data.partId %>" disabled><i class="fa fa-check"></i>Create</button>
+        <button type="button" id="gh-create-series-cancel" class="btn btn-link">Cancel</button>
     </div>
 </form>


### PR DESCRIPTION
* [x] Set label font-weight to 400px, color to dark grey
* [x] Input field: width: 55%, font-weight 400, padding: 5px 10px 3px 10px, height 41px, font-color: #171717 font-size: 28px (same as series title h1)
* [x] Adjust placeholder copy to "Enter a title for the new event series"
* [x] Add a "Cancel" secondary button: On click go back to display current active series

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6484535/d9555aae-c274-11e4-9768-3115fa49342a.png)


**Additionally, on all primary buttons:**
* [x] On .btn-default: font-weight: 700
* [x] On .btn: padding: 10px 20px 8px 18px

