### PR TITLE
Only display home icon when we are not on home screen

### DIFF
--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -119,7 +119,7 @@
 
         <!-- Subheader picker select elements -->
         <script id="gh-subheader-pickers-template" type="text/template">
-            <button type="button" class="btn btn-default gh-btn-secondary gh-btn-reverse gh-home pull-left"><i class="fa fa-home"></i></button>
+            <button type="button" class="btn btn-default gh-btn-secondary gh-btn-reverse gh-home pull-left" style="display: none;"><i class="fa fa-home"></i></button>
             <%= _.partial('subheader-pickers') %>
             <div id="gh-subheader-visibility"><!-- --></div>
         </script>

--- a/apps/timetable/admin/ui/js/index.js
+++ b/apps/timetable/admin/ui/js/index.js
@@ -333,13 +333,22 @@ define(['gh.core', 'gh.constants', 'gh.admin-listview', 'gh.admin-batch-edit', '
     var setView = function(view, data) {
         switch(view) {
             case constants.views.NEW_SERIES:
+                // Show the home button
+                $('.gh-home').show();
+                // Render the new series form
                 renderNewSeriesForm(data);
                 break;
             case constants.views.BATCH_EDIT:
+                // Show the home button
+                $('.gh-home').show();
+                // Render the batch edit
                 renderBatchEdit(data);
                 break;
             // Show the editable parts for the admin by default
             default:
+                // Hide the home button
+                $('.gh-home').hide();
+                // Render the editable parts
                 renderEditableParts();
                 break;
         }


### PR DESCRIPTION
As a principle we should not display navigation links / icons to states that we are currently on. In this spirit, the home icon should only be displayed when we are !home

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6445181/262dd116-c0fa-11e4-829e-5e7761a979ba.png)
