### PR TITLE
Adjust 'Add event' logic 

### DIFF
--- a/shared/gh/files/config.json
+++ b/shared/gh/files/config.json
@@ -5,7 +5,8 @@
             "Class",
             "Seminar",
             "Other"
-        ]
+        ],
+        "default": "Lecture"
     },
     "terms":
         {


### PR DESCRIPTION
When clicking the 'Add event' button:
 * [x] The new event should have last event week + 1 week
 * [x] Same title, day, start/end hour, lecturer, venue, type as the previous event
 * [x] If last event is W8, push it out to OT, but keep +1 week pattern
 * [x] If there are no events, it should be W1 with default metadata set (title inheriting module, lecture etc...)
 * [x] Newly added events should be in selected state

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6443788/57aa4d90-c0f1-11e4-80c1-826861fd4b8a.png)

