### PR TITLE
Adjust Borrow series modal styling

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -842,11 +842,29 @@ tr.info .gh-event-delete button {
 /* BORROWING */
 /*************/
 
+#gh-borrow-series-modal .list-group-item .list-group {
+    margin-bottom: 30px;
+}
+
+#gh-borrow-series-modal .list-group .list-group-item .gh-list-description {
+    font-size: 16px;
+    font-weight: 700;
+}
+
+#gh-borrow-series-modal .list-group .list-group-item .gh-list-description p {
+    opacity: 0.75;
+}
+
 #gh-borrow-series-modal .list-group .list-group-item .list-group .list-group-item .gh-list-description {
-    padding-bottom: 10px;
-    padding-top: 10px;
+    font-weight: 400;
+    padding: 10px 0 10px 15px;
     position: relative;
     width: 210px;
+}
+
+#gh-borrow-series-modal .list-group .list-group-item .list-group .list-group-item .gh-list-description p {
+    font-size: 15.3px;
+    opacity: 1;
 }
 
 #gh-borrow-series-modal .list-group .list-group-item .gh-list-action,

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -669,16 +669,9 @@ tbody tr:last-child > td.fc-widget-content {
 
 .chosen-container .chosen-single,
 .chosen-container .chosen-drop {
-    -webkit-box-shadow: 0 3px 5px rgba(0, 0, 0, 0.30);
-       -moz-box-shadow: 0 3px 5px rgba(0, 0, 0, 0.30);
-            box-shadow: 0 3px 5px rgba(0, 0, 0, 0.30);
-}
-
-.gh-chosen-inverted .chosen-container .chosen-single,
-.gh-chosen-inverted .chosen-container .chosen-drop {
-    -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.30);
-       -moz-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.30);
-            box-shadow: 0 1px 1px rgba(0, 0, 0, 0.30);
+    -webkit-box-shadow: none;
+       -moz-box-shadow: none;
+            box-shadow: none;
 }
 
 .chosen-container .chosen-single span,

--- a/shared/gh/partials/borrow-series-modal.html
+++ b/shared/gh/partials/borrow-series-modal.html
@@ -7,10 +7,10 @@
             </div>
             <div class="modal-body">
                 <form class="form-horizontal gh-chosen-inverted">
-                    <select id="gh-borrow-series-tripos" class="chosen-select" data-placeholder="Choose a Tripos" style="display: none; width: 46%;" tabindex="-1">
+                    <select id="gh-borrow-series-tripos" class="chosen-select" data-placeholder="Choose a Tripos" style="display: none; width: 300px;" tabindex="-1">
                         <%= _.partial('subheader-picker', {'data': data}) %>
                     </select>
-                    <select id="gh-borrow-series-part" class="chosen-select" data-placeholder="Choose a part/paper" style="display: none; width: 46%;" tabindex="-1">
+                    <select id="gh-borrow-series-part" class="chosen-select" data-placeholder="Choose a part/paper" style="display: none; width: 160px;" tabindex="-1">
                         <%= _.partial('subheader-part', {'data': data}) %>
                     </select>
                 </form>


### PR DESCRIPTION
* [x] Increase font-weight of items to 400, and the part parent item (American Literature M.Phil) to 700
* [x] Increase font-size to 16px for part parent item, and 15.3px to list items
* [x] Add 15px left padding to list items
* [x] Add 30px bottom margin to .list-group
* [x] Remove drop shadow from tripos and part selectors + add grey borders (  ) as per #243 
* [x] Make opacity 1 for list items, and make it 0.75 for the parent part item
* [x] Add 3px padding-top to the parent part item to align with down caret icon
* [x] Make tripos selector dropdown width 300px, the part selector dropdown width 160px
* [x] Remove focus outlines

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6484066/4833e576-c270-11e4-869f-6c63b5cf068f.png)

