### PR TITLE
Add better empty state for terms

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -675,6 +675,20 @@
     padding: 0 0 0 8px;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container .gh-batch-edit-events-container-empty {
+    font-size: 15px;
+    font-weight: 400;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot .gh-batch-edit-events-container-empty {
+    display: none !important;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container .gh-batch-edit-events-container-empty td {
+    padding: 20px !important;
+    text-align: center;
+}
+
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox,
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td .checkbox {
     font-size: 16px;

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -338,6 +338,11 @@
     background-color: #FFF !important;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container .gh-batch-edit-events-container-empty {
+    background-color: #F5F5F5;
+    color: #999;
+}
+
 tr.info .gh-event-delete button i {
     color: #4D4D4D;
 }

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -91,13 +91,19 @@
                                 </tr>
                             </thead>
                             <tbody>
-                            <% _.each(term.events, function(ev) { %>
-                                <%= _.partial('admin-batch-edit-event-row', {
-                                    'ev': ev,
-                                    'gh': gh,
-                                    'utils': gh.utils
-                                }) %>
-                            <% }); %>
+                                <tr class="gh-batch-edit-events-container-empty" <% if (term.events.length) { %>style="display: none;"<% } %>>
+                                    <td colspan="7">
+                                        <p>No events in <%- term.name %> yet</p>
+                                        <button type="button" class="btn btn-default gh-btn-secondary gh-new-events"><i class="fa fa-plus-square"></i> Add events</button>
+                                    </td>
+                                </tr>
+                                <% _.each(term.events, function(ev) { %>
+                                    <%= _.partial('admin-batch-edit-event-row', {
+                                        'ev': ev,
+                                        'gh': gh,
+                                        'utils': gh.utils
+                                    }) %>
+                                <% }); %>
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
If a term does not contain any events in a series, we should improve the default rendering state:

* [x] Add contextual help copy "No events in {{Term name}} yet"
* [x] Add events secondary button, with interaction defined below

I could simply hack this in with a new 7 colspan row, and some basic styling:
* [x] #f5f5f5 background color
* [x] 15px font size, 400 weight, #999 color
* [x] secondary button styling for Add events
* [x] 20px padding on the container
* [x] 100% container width, centre aligned text

**Interactions**
* [x] Add events should *ideally* add as many events as needed for each week in that specific term for the current year. If this is not possible, just default to 8 events, from W1 to W8
* [x] The above would trigger batch edit mode and the usual edit  /save cycle

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6486263/9f5b3a82-c281-11e4-9fae-96405a68bb2b.png)


