### PR TITLE
Adjust admin home page contextual help

### DIFF
--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -94,7 +94,7 @@
 
         <!-- Tripos help template -->
         <script id="gh-tripos-help-template" type="text/template">
-            <p class="gh-tripos-help">To start editing timetables choose a tripos from the list above, or select from your list below</p>
+            <p class="gh-tripos-help">To edit timetable data<br/>choose a tripos from the<br/>dropdown list above,<br/>or select one of the parts on<br/>the right</p>
         </script>
 
         <!-- Login template -->

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -85,7 +85,7 @@
 
 .gh-tripos-help {
     display: table-cell;
-    font-size: 23px;
+    font-size: 20px;
     font-weight: 100;
     height: 415px;
     padding: 45px;
@@ -95,10 +95,10 @@
 .gh-academic-year-select {
     display: table-cell;
     font-size: 18px;
-    font-weight: 400;
+    font-weight: 100;
     height: 100px;
     line-height: 40px;
-    padding-left: 30px;
+    padding-left: 45px !important;
     vertical-align: middle;
 }
 

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -68,7 +68,7 @@
 }
 
 .gh-tripos-help {
-    color: #FFF;
+    color: #BEBEBE;
 }
 
 #gh-page-container #gh-right-container #gh-subheader,


### PR DESCRIPTION
 * [x] Adjust copy and line breaking (after '...above,') as per image
 * [x] Drop color for text to: #BEBEBE
 * [x] Drop font-size to 20px

On year display:
 * [x] Drop font-weight to 100
 * [x] Adjust left padding to 45px to line up with help text

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6442042/a4977266-c0e4-11e4-8af9-8cbd6dbb4386.png)
