### PR TITLE
Admin UI: Optimise event data empty states 

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -774,7 +774,7 @@
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-type:empty:hover::before {
-    content: 'Add type' !important;
+    content: 'Add type';
 }
 
 .gh-batch-edit-events-container .gh-event-type.gh-editing::before {

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -647,6 +647,16 @@
     padding: 6px 0px 6px 15px;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-type:empty:hover::before,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-location:empty:hover::before,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-organisers[title]:empty:hover::before {
+    content: 'Add lecturer';
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-location:empty:hover::before {
+    content: 'Add location';
+}
+
 #gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot {
     margin-bottom: 10px;
     margin-top: 0;
@@ -752,7 +762,7 @@
     height: 34px;
 }
 
-.gh-batch-edit-events-container .gh-event-type::before {
+.gh-batch-edit-events-container .gh-event-type:not(:empty)::before {
     border-radius: 12px;
     content: attr(data-first);
     display: inline-block;
@@ -761,6 +771,10 @@
     padding: 1px;
     text-align: center;
     width: 20px;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-type:empty:hover::before {
+    content: 'Add type' !important;
 }
 
 .gh-batch-edit-events-container .gh-event-type.gh-editing::before {

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -298,14 +298,17 @@
     border-color: #62326E;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-type:empty:hover::before,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-location:empty:hover::before,
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-organisers[title]:empty:hover::before {
+    background-color: transparent;
+    color: #BEBEBE;
+}
+
 /* Event type */
 .gh-batch-edit-events-container .gh-event-type::before {
     background-color: #555;
     color: #FFF;
-}
-
-.gh-batch-edit-events-container .gh-event-type[data-first=""]::before {
-    display: none;
 }
 
 .gh-batch-edit-events-container .gh-event-type[data-type="Lecture"]::before {

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -635,7 +635,7 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
             'cssclass': 'gh-jeditable-form',
             'placeholder': '',
             'select': true,
-            'tooltip': 'Click to edit event notes',
+            'tooltip': 'Click to edit the event type',
             'type': 'event-type-select',
             'callback': function(value, settings) {
                 // Focus the edited field td element after submitting the value
@@ -651,7 +651,7 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
             'cssclass': 'gh-jeditable-form',
             'placeholder': '',
             'select': true,
-            'tooltip': 'Click to edit organisers',
+            'tooltip': 'Click to add a lecturer for this event',
             'type': 'organiser-autosuggest',
             'callback': function(value, settings) {
                 // Focus the edited field td element after submitting the value

--- a/shared/gh/partials/admin-batch-edit-event-row.html
+++ b/shared/gh/partials/admin-batch-edit-event-row.html
@@ -29,9 +29,9 @@
             <% } %>
         <% }); %>
     </td>
-    <td class="gh-event-organisers" tabindex="0" title="Click to edit the event organisers"><%- organiserString.join(', ') %></td>
-    <td class="gh-jeditable-events gh-event-location" tabindex="0" title="Click to edit the event location"><%- ev.location %></td>
-    <td class="gh-jeditable-events-select gh-event-type" data-type="<%- ev.notes %>" data-first="<% if (ev.notes) { %><%- ev.notes.substr(0,1) %><% } %>" tabindex="0" title="Click to edit the event notes">
+    <td class="gh-event-organisers" tabindex="0" title="Click to add a lecturer for this event"><%- organiserString.join(', ') %></td>
+    <td class="gh-jeditable-events gh-event-location" tabindex="0" title="Click to add a location for this event"><%- ev.location %></td>
+    <td class="gh-jeditable-events-select gh-event-type" data-type="<%- ev.notes %>" data-first="<% if (ev.notes) { %><%- ev.notes.substr(0,1) %><% } %>" tabindex="0" title="Click to edit the event type">
     <%- ev.notes %></td>
     <td class="gh-event-delete" tabindex="0" title="Select the row and click to delete this event">
         <button type="button" class="btn btn-link"><i class="fa fa-trash"></i></button>


### PR DESCRIPTION
* [x] On hover: show "Add lecturer" in light grey, or "Add location" for location
* [x] Adjust on long hover tooltip copy to "Click to add a lecturer for this event", "Click to add a location for this event"
* [x] Remove outline

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6464694/e4ac6b5c-c1b3-11e4-80f8-3331c09450ee.png)


Generally we should refer to organisers as "lecturers" in this app I think.