### PR TITLE
Button not vertically centered in module listview

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -540,7 +540,7 @@ tbody tr:last-child > td.fc-widget-content {
 
 .list-group .list-group-item .gh-list-action .btn-link {
     height: 100%;
-    padding: 16px;
+    padding: 13px 16px;
     position: absolute;
     right: 0;
     top: 0;


### PR DESCRIPTION
When the module doesn't have additional info, the button is not properly vertically centered. 

![screen shot 2015-03-10 at 09 51 34](https://cloud.githubusercontent.com/assets/2194396/6572552/fb7bdfaa-c70a-11e4-8b13-96ec2d535f23.png)
