### PR TITLE
Minor adjustments on calendar print stylesheets

### DIFF
--- a/apps/admin/ui/index.html
+++ b/apps/admin/ui/index.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>Administration</title>
+        <title>Timetable Global Administration</title>
 
         <meta name="viewport" content="width=device-width">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/apps/timetable/ui/index.html
+++ b/apps/timetable/ui/index.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <title>My timetable</title>
+        <title>My Timetable</title>
 
         <meta name="viewport" content="width=device-width">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/shared/gh/js/utils/gh.utils.js
+++ b/shared/gh/js/utils/gh.utils.js
@@ -21,6 +21,28 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
     ///////////////
 
     /**
+     * Set the title of the document. Depending on the interface that's loaded up, the title will be prefixed with:
+     *     - 'My Timetable' when the student UI is loaded
+     *     - 'Timetable Administration' when the administrator UI is loaded
+     *     
+     * @param {String}    [title]    The title to set to the document
+     */
+    var setDocumentTitle = exports.setDocumentTitle = function(title) {
+        if (title && !_.isString(title)) {
+            throw new Error('An invalid value for title was provided');
+        }
+
+        // Default the previx to 'My Timetable'. If the admin UI is loaded
+        // up the prefix should be 'Timetable Administration'
+        var prefix = 'My Timetable ';
+        if ($('body').data('isadminui')) {
+            prefix = 'Timetable Administration ';
+        }
+
+        document.title = prefix + title.trim();
+    };
+
+    /**
      * Generates a random 10 character sequence of upper and lowercase letters.
      *
      * @param  {Boolean}    toLowerCase    Whether or not the string should be returned lowercase

--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -296,6 +296,8 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
 
     /**
      * Set the document title to the currently selected date range
+     *
+     * @private
      */
     var setDocumentTitle = function() {
         if (!$('body').data('isadminui')) {

--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -56,6 +56,8 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
         setPeriodLabel();
         // Set the term label
         setTermLabel();
+        // Set the document title
+        setDocumentTitle();
         // Track the week change in GA
         gh.utils.sendTrackingEvent('calendar', 'view', 'Navigate to ' + action + ' week');
 
@@ -103,6 +105,8 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
         setPeriodLabel();
         // Set the term label
         setTermLabel();
+        // Set the document title
+        setDocumentTitle();
         // Track the term change in GA
         gh.utils.sendTrackingEvent('calendar', 'view', 'Navigate to ' + action + ' ' + term.label + ' term');
 
@@ -134,6 +138,8 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
         setPeriodLabel();
         // Set the term label
         setTermLabel();
+        // Set the document title
+        setDocumentTitle();
 
         // Track the view change in GA
         gh.utils.sendTrackingEvent('calendar', 'view', 'Change calendar view to ' + currentView);
@@ -156,6 +162,8 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
         setPeriodLabel();
         // Set the term label
         setTermLabel();
+        // Set the document title
+        setDocumentTitle();
 
         // Track the today click in GA
         gh.utils.sendTrackingEvent('calendar', 'view', 'Navigate to today');
@@ -274,7 +282,6 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
      * @private
      */
     var setTermLabel = function() {
-
         // Get the current term
         var term = gh.utils.getTerm(getCurrentViewDate());
 
@@ -285,6 +292,18 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
         }
 
         $('#gh-toolbar-label-term').html(label);
+    };
+
+    /**
+     * Set the document title to the currently selected date range
+     */
+    var setDocumentTitle = function() {
+        if (!$('body').data('isadminui')) {
+            var title = calendar.fullCalendar('getView').title;
+
+            // Set the document title
+            gh.utils.setDocumentTitle(title);
+        }
     };
 
 

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -607,6 +607,18 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     //  GENERAL  //
     ///////////////
 
+    // Test the 'setDocumentTitle' functionality
+    QUnit.test('setDocumentTitle', function(assert) {
+        // Verify that only string values are allowed as a parameter
+        assert.throws(function() {
+            gh.utils.setDocumentTitle(123);
+        }, 'Verify that only string values are allowed as a parameter');
+
+        // Verify that the document title can be set
+        gh.utils.setDocumentTitle('QUnit Test');
+        assert.equal(document.title, 'My Timetable QUnit Test', 'Verify that the document title can be set');
+    });
+
     // Test the 'generateRandomString' functionality
     QUnit.test('generateRandomString', function(assert) {
 


### PR DESCRIPTION
**Week view:**
* [x] Can we add current week to the title? "My timetable Feb. 26 - Mar. 03"
* [x] Can we expand calendar to full screen / page height?

** Month view**
Good as it is

**Day view**
* [x] Can we expand to 100% height?
* [x] Can we include the date of the day show in the title 23 February, 20145?

![my_timetable_pdf__1_page_](https://cloud.githubusercontent.com/assets/117483/6486732/cd2103ae-c284-11e4-9d6d-bed484aa249e.png)

![my_timetable_pdf__1_page_](https://cloud.githubusercontent.com/assets/117483/6486838/9aa35ee4-c285-11e4-8a29-ab5ec4c66f82.png)


