### PR TITLE
Polish the batch editor

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -406,7 +406,8 @@
 
 #gh-batch-edit-header input[type="text"],
 #gh-batch-edit-header select {
-    font-weight: 200;
+    font-weight: 400;
+    height: 32px !important;
     padding-left: 6px;
     padding-right: 6px;
 }
@@ -443,7 +444,8 @@
 }
 
 #gh-batch-edit-header th > * {
-    height: 39px;
+    height: 32px;
+    padding: 6px 12px;
     width: 100%;
 }
 
@@ -454,29 +456,22 @@
     vertical-align: middle;
 }
 
-#gh-batch-edit-header {
-    padding-bottom: 12px;
-}
-
 #gh-batch-edit-header .gh-batch-edit-header-description {
     vertical-align: middle;
 }
 
 #gh-batch-edit-header.gh-batch-edit-time-open {
-    border-bottom-style: solid;
-    border-bottom-width: 2px;
-    height: 51px;
-    padding-bottom: 61px;
+    height: 50px;
+    padding-bottom: 50px;
 }
 
 #gh-batch-edit-header.gh-batch-edit-time-open #gh-batch-edit-time {
-    border-bottom: none !important;
-    border-style: solid;
-    border-width: 2px;
-    bottom: -16px;
-    height: 55px !important;
-    margin-top: -53px;
-    padding-top: 10px;
+    border: none !important;
+    bottom: -20px;
+    height: 60px !important;
+    margin-top: -64px;
+    padding-bottom: 20px;
+    padding-top: 16px;
     position: relative;
     right: 0px;
     z-index: 9999;
@@ -484,32 +479,39 @@
 
 #gh-batch-edit-container #gh-batch-edit-date-container {
     clear: both;
-    height: 0;
+    max-height: 0;
     opacity: 0;
     overflow: hidden;
-    padding: 0;
-    -webkit-transition: height .2s, opacity .2s, padding .3s;
-       -moz-transition: height .2s, opacity .2s, padding .3s;
-            transition: height .2s, opacity .2s, padding .3s;
+    padding: 0 0 0 15px !important;
+    -webkit-transition: max-height .3s, opacity .3s;
+       -moz-transition: max-height .3s, opacity .3s;
+            transition: max-height .3s, opacity .3s;
 }
 
 .gh-batch-edit-time-open + #gh-batch-edit-date-container {
-    height: auto !important;
+    max-height: 1000px !important;
     opacity: 1 !important;
-    padding: 20px 0 0 !important;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-term-description {
     float: left;
-    width: 150px;
+    margin-top: 20px;
+    width: 140px;
+}
+
+#gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-term-description small {
+    font-size: 90%;
+    font-weight: 400;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-term-description h2 {
-    font-size: 20px;
-    margin: 7px 0 0;
+    font-size: 18px;
+    margin: 5px 0 0;
+    font-weight: 600;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container {
+    margin-top: 20px;
     overflow: auto;
     width: 80%;
 }
@@ -518,30 +520,33 @@
     border-collapse: separate;
     border-spacing: 1px;
     display: table;
-    margin-bottom: 12px;
+    margin-bottom: 20px;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox {
     display: table-cell;
-    height: 40px;
-    min-width: 77px;
+    min-height: 36px;
+    min-width: 62px;
     overflow: hidden;
     padding: 0;
     vertical-align: middle;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox label {
-    font-size: 20px;
+    font-size: 18px;
     font-weight: 400;
-    padding: 5px 16px 1px;
+    padding: 3px 5px 0 5px;
 }
 
-#gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox label i.fa-square-o {
-    margin-left: 2px;
+#gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox label i.fa-square-o,
+#gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox label i.fa-check-square-o {
+    position: relative;
+    top: 1px;
 }
 
+#gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox label i.fa-square-o,
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox.gh-batch-edit-date-picker-selected label i {
-    margin-left: 2px;
+    margin-left: 4px;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox.gh-batch-edit-date-picker-selected label i.fa-square-o,
@@ -555,7 +560,7 @@
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox.gh-batch-edit-date-picker-selected {
     border-style: solid;
-    border-width: 3px;
+    border-width: 2px;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox.gh-batch-edit-date-picker-selected label {
@@ -580,19 +585,33 @@
     height: 30px;
 }
 
+#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-day-picker,
+#gh-batch-edit-container .gh-batch-edit-time-picker select.form-control {
+    font-size: 16px;
+    font-weight: 400;
+}
+
 #gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-hours-picker,
 #gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-minutes-picker {
     width: 50px;
 }
 
-#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-date-start,
-#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-date-end {
+#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-date-start {
     margin: 0 0 7px 17px;
+}
+
+#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-date-end {
+    margin: 0 0 7px 5px;
+}
+
+#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-date-to {
+    margin: 5px 0 0 5px;
 }
 
 #gh-batch-edit-container .gh-batch-edit-date-add-day {
     clear: both;
     display: block;
+    margin-bottom: 15px;
 }
 
 /* Terms */

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -245,18 +245,12 @@
             box-shadow: 0 0px 15px #666;
 }
 
-#gh-batch-edit-header.gh-batch-edit-time-open,
 #gh-batch-edit-header.gh-batch-edit-time-open #gh-batch-edit-time {
-    border-bottom-color: #EEE;
-}
-
-#gh-batch-edit-header.gh-batch-edit-time-open #gh-batch-edit-time {
-    border-color: #EEE;
+    background-color: #F4F4F4;
     color: #171717;
 }
 
-#gh-batch-edit-container,
-#gh-batch-edit-header.gh-batch-edit-time-open #gh-batch-edit-time {
+#gh-batch-edit-container {
     background-color: #FFF;
 }
 
@@ -286,6 +280,10 @@
     border-right-color: #DDD;
 }
 
+#gh-batch-edit-container #gh-batch-edit-date-container {
+    background-color: #F4F4F4;
+}
+
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox {
     background-color: #FFF;
 }
@@ -296,6 +294,11 @@
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox.gh-batch-edit-date-picker-selected {
     border-color: #62326E;
+}
+
+#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-day-picker,
+#gh-batch-edit-container .gh-batch-edit-time-picker select.form-control {
+    color: #171717;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-type:empty:hover::before,

--- a/shared/gh/js/utils/gh.utils.time.js
+++ b/shared/gh/js/utils/gh.utils.time.js
@@ -221,8 +221,8 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
         return _.find(terms, function(term) {
 
             // Convert the dates from ISO to UNIX for easier calculation
-            var startDate = convertISODatetoUnixDate(moment(term.start).utc().format());
-            var endDate = convertISODatetoUnixDate(moment(term.end).utc().format());
+            var startDate = convertISODatetoUnixDate(moment(term.start).toISOString());
+            var endDate = convertISODatetoUnixDate(moment(term.end).toISOString());
 
             // Only use an offset for the week calculation when specified
             if (!usePrecise) {
@@ -231,7 +231,7 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
                 // E.g. A term starts on Tuesday 13th February, but the academic weeks always start on a Thursday.
                 //      This means that the first academic week of that term starts on the 13th and ends on the 14th.
                 //      The second academic week will start on Thursday 15th February.
-                var datePlus = convertISODatetoUnixDate(moment(date).add({'days': 6}).utc().format());
+                var datePlus = convertISODatetoUnixDate(moment(date).add({'days': 6}).toISOString());
                 /* istanbul ignore else */
                 if (date < startDate && datePlus >= startDate) {
                     date = datePlus;
@@ -567,8 +567,8 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
             if (name !== 'OT') {
                 _terms.push({
                     'name': name,
-                    'start': moment(term.start).utc().format(),
-                    'end': moment(term.end).utc().format(),
+                    'start': moment(term.start).toISOString(),
+                    'end': moment(term.end).toISOString(),
                     'events': term.events
                 });
             }
@@ -580,7 +580,7 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
             _.each(terms['OT'].events, function(event) {
                 _terms.push({
                     'name': 'OT',
-                    'start': moment(event.start).utc().format(),
+                    'start': moment(event.start).toISOString(),
                     'events': [event]
                 });
             });

--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -37,8 +37,6 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
             'termsInUse': termsInUse,
             'daysInUse': daysInUse
         }, $('#gh-batch-edit-date-container'));
-
-        $('#gh-batch-edit-time').removeAttr('disabled');
     };
 
     /**
@@ -59,13 +57,9 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
         var termsInUse = getTermsInUse($rows);
         // Get the unique days in the week to render time pickers for
         var daysInUse = getDaysInUse($rows);
-        // Render the batch date editor if at least one week was selected
-        if (weeksInUse.length || $terms.length) {
+        // Render the batch date editor if at least one week was selected that isn't out of term
+        if (weeksInUse.length && termsInUse.length) {
             renderBatchDate(maxNumberOfWeeks, weeksInUse, termsInUse, daysInUse);
-        // If no weeks where selected, close the batch date edit header
-        } else {
-            $('#gh-batch-edit-header').removeClass('gh-batch-edit-time-open');
-            $('#gh-batch-edit-time').attr('disabled', 'disabled');
         }
     };
 

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -124,21 +124,21 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
         if ($lastEventInTerm.length) {
             eventObj.ev = data && data.eventObj ? data.eventObj : {
                 'displayName': $lastEventInTerm.find('.gh-event-description').text(),
-                'end': moment($($lastEventInTerm.find('.gh-event-date')).attr('data-end')).add(7, 'days').utc().format(),
+                'end': moment($($lastEventInTerm.find('.gh-event-date')).attr('data-end')).add(7, 'days').toISOString(),
                 'location': $lastEventInTerm.find('.gh-event-location').text(),
                 'notes': $lastEventInTerm.find('.gh-event-type').attr('data-type') || gh.config.events.default,
                 'organisers': getOrganiserObjects($lastEventInTerm.find('.gh-event-organisers-fields')),
-                'start': moment($($lastEventInTerm.find('.gh-event-date')).attr('data-start')).add(7, 'days').utc().format(),
+                'start': moment($($lastEventInTerm.find('.gh-event-date')).attr('data-start')).add(7, 'days').toISOString(),
             };
         // If no events were previously added to the term, create a default event object
         } else {
             eventObj.ev = data && data.eventObj ? data.eventObj : {
                 'displayName': $('.gh-jeditable-series-title').text(),
-                'end': moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 14, 0, 0, 0])).utc().format(),
+                'end': moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 14, 0, 0, 0])).toISOString(),
                 'location': '',
                 'notes': gh.config.events.default,
                 'organisers': [],
-                'start': moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 13, 0, 0, 0])).utc().format(),
+                'start': moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 13, 0, 0, 0])).toISOString(),
             };
         }
 
@@ -156,6 +156,8 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
         toggleSubmit();
         // Enable batch editing of dates
         toggleBatchEditDateEnabled();
+        // Trigger a change event on the newly added row to update the batch edit
+        $eventContainer.find('.gh-select-single').trigger('change');
     };
 
     /**

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -283,7 +283,7 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
      * @private
      */
     var toggleBatchEditDateEnabled = function() {
-        if ($('.gh-batch-edit-events-container tbody .gh-select-single:checked').length) {
+        if ($('.gh-batch-edit-events-container:not(.gh-ot) tbody .gh-select-single:checked').length) {
             $('#gh-batch-edit-time').removeAttr('disabled');
         } else {
             $('#gh-batch-edit-header').removeClass('gh-batch-edit-time-open');

--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -392,7 +392,7 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
         // Get the start date from the current calendar view
         var viewStartDate = calendar.fullCalendar('getDate');
         // Convert the Moment object to a UTC date
-        return gh.utils.convertISODatetoUnixDate(moment(viewStartDate).utc().format());
+        return gh.utils.convertISODatetoUnixDate(moment(viewStartDate).toISOString());
     };
 
     /**

--- a/shared/gh/js/views/gh.datepicker.js
+++ b/shared/gh/js/views/gh.datepicker.js
@@ -93,8 +93,8 @@ define(['gh.core', 'moment', 'clickover', 'jquery-datepicker'], function(gh, mom
         var entries = getFormValues();
 
         // Generate the start and end dates
-        var startDate = moment(entries.date).add({'h': entries.startHour, 'm': entries.startMinutes}).utc().format();
-        var endDate = moment(entries.date).add({'h': entries.endHour, 'm': entries.endMinutes}).utc().format();
+        var startDate = moment(entries.date).add({'h': entries.startHour, 'm': entries.startMinutes}).toISOString();
+        var endDate = moment(entries.date).add({'h': entries.endHour, 'm': entries.endMinutes}).toISOString();
 
         // Return the full dates
         return {

--- a/shared/gh/partials/admin-batch-edit-date.html
+++ b/shared/gh/partials/admin-batch-edit-date.html
@@ -1,7 +1,7 @@
 <% var termNames = _.pluck(termsInUse, 'name'); %>
 
 <div id="gh-batch-edit-date-term-description">
-    <small>Selected</small>
+    <small>Selected terms</small>
     <h2>
     <% _.each(termsInUse, function(term) { %>
         <%- term.label %><br/>
@@ -10,7 +10,7 @@
 </div>
 <div id="gh-batch-edit-date-picker-container" data-terms="<%- termNames.join(',') %>">
     <!-- Show the number of weeks that are selected -->
-    <small><%- weeksInUse.length %> week<% if (weeksInUse.length !== 1) { %>s<% } %> selected</small>
+    <small><%- weeksInUse.length %> week<% if (weeksInUse.length !== 1) { %>s<% } %> in selection</small>
     <div id="gh-batch-edit-date-picker">
         <% var weekUsed = _.indexOf(weeksInUse, 0) !== -1 %>
         <div class="checkbox <% if (weekUsed) { %>gh-batch-edit-date-picker-selected<% } %>">
@@ -27,7 +27,7 @@
             <% var weekUsed = _.indexOf(weeksInUse, weekNumber) !== -1 %>
             <div class="checkbox <% if (weekUsed) { %>gh-batch-edit-date-picker-selected<% } %>">
                 <label>
-                    <input type="checkbox" value="<%- weekNumber %>" <% if (weekUsed) { %>checked<% } %>><%- gh.utils.addLeadingZero(weekNumber) %> <i class="fa fa-square-o"></i><i class="fa fa-check-square-o"></i>
+                    <input type="checkbox" value="<%- weekNumber %>" <% if (weekUsed) { %>checked<% } %>>W<%- weekNumber %> <i class="fa fa-square-o"></i><i class="fa fa-check-square-o"></i>
                 </label>
             </div>
         <% } %>
@@ -55,6 +55,7 @@
                     <% } %>
                 </select>
             </div>
+            <p id="gh-batch-edit-date-to" class="pull-left">to</p>
             <div id="gh-batch-edit-date-end" class="pull-left">
                 <select id="gh-batch-edit-hours-end" class="form-control gh-batch-edit-hours-picker">
                     <% for (var i = 7; i < 20; i += 1) { %>

--- a/shared/gh/partials/admin-batch-edit-date.html
+++ b/shared/gh/partials/admin-batch-edit-date.html
@@ -12,12 +12,6 @@
     <!-- Show the number of weeks that are selected -->
     <small><%- weeksInUse.length %> week<% if (weeksInUse.length !== 1) { %>s<% } %> in selection</small>
     <div id="gh-batch-edit-date-picker">
-        <% var weekUsed = _.indexOf(weeksInUse, 0) !== -1 %>
-        <div class="checkbox <% if (weekUsed) { %>gh-batch-edit-date-picker-selected<% } %>">
-            <label>
-                <input type="checkbox" value="0" <% if (weekUsed) { %>checked<% } %>>OT <i class="fa fa-square-o"></i><i class="fa fa-check-square-o"></i>
-            </label>
-        </div>
         <% var totalWeeks = numberOfWeeks%>
         <!-- Keep rendering new weeks until the amount of weeks left to render is 0 -->
         <% while (numberOfWeeks) { %>
@@ -31,6 +25,12 @@
                 </label>
             </div>
         <% } %>
+        <% var weekUsed = _.indexOf(weeksInUse, 0) !== -1 %>
+        <div class="checkbox <% if (weekUsed) { %>gh-batch-edit-date-picker-selected<% } else { %> hide<% } %>">
+            <label>
+                <input type="checkbox" value="0" <% if (weekUsed) { %>checked<% } %>>OT <i class="fa fa-square-o"></i><i class="fa fa-check-square-o"></i>
+            </label>
+        </div>
     </div>
     <% _.each(daysInUse, function(dayInUse, index) { %>
         <div class="form-inline gh-batch-edit-time-picker">

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -43,7 +43,7 @@
                                     <input type="text" id="gh-batch-edit-title" placeholder="Event titles">
                                 </th>
                                 <th>
-                                    <button type="button" id="gh-batch-edit-time" class="btn btn-default pull-right" disabled><i class="fa fa-calendar"></i> Time/dates</button>
+                                    <button type="button" id="gh-batch-edit-time" class="btn btn-default pull-right" disabled><i class="fa fa-calendar"></i> Dates &amp; times</button>
                                 </th>
                                 <th class="gh-batch-event-organisers">
                                     <input type="text" id="gh-batch-edit-organisers" placeholder="Organisers">


### PR DESCRIPTION
**Functionality**
 * [x] Fix week tick/untick functionality: On untick all given weeks should be removed from the selection, on tick the given weeks should be added at the right place for each selected term, copying in any event metadata that is present in the selection
 * [x] I would treat OT as a resulting edge case, not as something you can specifically create. With this in mind, I would remove OT from the week tick display, and only show (at the end) if there is an OT event in the selection, discouraging "creation" of OT events via batch edit
 * [x] "Add another day" should add another day for each ticked weeks, inheriting the previous day's time
 * [x] Selecting a start hour should automatically adjust the end hour to +1 hour
 * [x] Batch edit should be available when empty terms are selected. All weeks would be unticked initially, ticking weeks would create events for all ticked weeks


**Styling & copy**
These should make the batch edit usable on 1280px width:
 * [x] Change copy of "Selected" to "Selected terms"
 * [x] Change copy of week selection label to "{{week_count}} weeks in selection"
 * [x] Change copy of main button to "Dates & times"
 * [x] Switch from zero padded week numbering to "W{{week_number}}" format ("W6") as it is displayed in the events, to help make the connection
 * [x] Increase <small> elements' font-weight to 400 ("Selected terms") and font-size to 90%
 * [x] Selected term labels: 18px font-size, margin 5px 0 0, font-weight: 600
 * [x] Tick box styling:
    * [x] Set the container cell min-width to 62px and min-height to 36px
    * [x] Drop border-width of the cell to 2px
    * [x] Inner <label> padding: 3px 5px 0 5px (both selected and unselected)
    * [x] Set checkbox icon, and <label> font-size to 18px
    * [x] Align checkbox with label text. For me position: relative; top: 1px; on the checkbox icon did it, but this might not be the best solution
    * [x] Add 4px margin-left to the tick icons
 * [x] Set the "#gh-batch-edit-date-container" top padding to 20px 0 15px 15px !important and background color to #F4F4F4, and remove border
 * [x] Style the active state of the Time/ Dates button
     * [x] background-color to #F4F4F4
     * [x] no border
     * [x] bottom: -20px; height: 60px !important; margin-top -64px; padding-top: 16px; padding bottom: 20px
 * [x] Set "#gh-batch-edit-header" padding-bottom: 50px, height: 50px
 * [x] Set "#gh-batch-edit-date-term-description" width to 140px
 * [x] Set "#gh-batch-edit-date-picker" margin-bottom to 20px
 * [x] On day and time selectors: color: #171717, font-weight: 400; font-size: 16px
 * [x] Add a "to" item between the start and end time (top and left padding 5px), end date container margin will need adjusting to: 0 0 7px 5px
 * [x] Somehow let's find a way to vertically align text in the select boxes (couldn't quickly do it)
 * [x] The event title, lecturer location input fields:
    * [x] height: 34px (will need 32px !important for the lecturer input)
    * [x] font-weight: 400
 * [x] "#gh-batch-edit-header th:first-child" text-align: right; font-size: 13px; color: #62326E; line-height: 1.2
 * [x] Open animation: the batch edit container should fast slide & fade down (elements inside don't move independently)
 * [x] Close animation: the batch edit container should fast slide & fade up (elements inside don't move independently)

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6574143/8938d182-c719-11e4-8d72-229b767adc6f.png)


