### PR TITLE
Utils not code covered

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,7 +169,8 @@ module.exports = function(grunt) {
                         'baseUrl': ".",
                         'src': [
                             'shared/gh/js/*.js',
-                            'shared/gh/js/controllers/*.js'
+                            'shared/gh/js/controllers/*.js',
+                            'shared/gh/js/utils/*.js'
                         ],
                         'instrumentedFiles': 'target/coverage',
                         'lcovReport': 'coverage/lcov',

--- a/shared/gh/js/gh.bootstrap.js
+++ b/shared/gh/js/gh.bootstrap.js
@@ -63,6 +63,7 @@ requirejs.config({
 
         // GH utilities
         'gh.utils': 'gh/js/utils/gh.utils',
+        'gh.utils.state': 'gh/js/utils/gh.utils.state',
         'gh.utils.templates': 'gh/js/utils/gh.utils.templates',
         'gh.utils.time': 'gh/js/utils/gh.utils.time',
 

--- a/shared/gh/js/utils/gh.utils.js
+++ b/shared/gh/js/utils/gh.utils.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], function(exports, templates, time) {
+define(['exports', 'gh.utils.state', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], function(exports, state, templates, time) {
 
 
     ///////////////
@@ -24,7 +24,7 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
      * Set the title of the document. Depending on the interface that's loaded up, the title will be prefixed with:
      *     - 'My Timetable' when the student UI is loaded
      *     - 'Timetable Administration' when the administrator UI is loaded
-     *     
+     *
      * @param {String}    [title]    The title to set to the document
      */
     var setDocumentTitle = exports.setDocumentTitle = function(title) {
@@ -35,6 +35,7 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
         // Default the previx to 'My Timetable'. If the admin UI is loaded
         // up the prefix should be 'Timetable Administration'
         var prefix = 'My Timetable ';
+        /* istanbul ignore next */
         if ($('body').data('isadminui')) {
             prefix = 'Timetable Administration ';
         }
@@ -277,13 +278,13 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
      * This function is mostly just a wrapper around jQuery.bootstrap.notify.js and supports all of the options documented
      * at https://github.com/goodybag/bootstrap-notify.
      *
-     * @param  {String}    [title]     The notification title
-     * @param  {String}    message     The notification message that will be shown underneath the title
-     * @param  {String}    [type]      The notification type. The supported types are `success`, `error` and `info`, as defined in http://getbootstrap.com/components/#alerts. By default, the `success` type will be used
-     * @param  {String}    [id]        Unique identifier for the notification, in case a notification can be triggered twice due to some reason. If a second notification with the same id is triggered it will be ignored
-     * @param  {String}    [sticky]    Whether or not the notification should be sticky. Defaults to `false`
-     * @throws {Error}                 Error thrown when no message has been provided
-     * @return {Boolean}               Returns true when the notification has been shown
+     * @param  {String}     [title]     The notification title
+     * @param  {String}     message     The notification message that will be shown underneath the title
+     * @param  {String}     [type]      The notification type. The supported types are `success`, `error` and `info`, as defined in http://getbootstrap.com/components/#alerts. By default, the `success` type will be used
+     * @param  {String}     [id]        Unique identifier for the notification, in case a notification can be triggered twice due to some reason. If a second notification with the same id is triggered it will be ignored
+     * @param  {Boolean}    [sticky]    Whether or not the notification should be sticky. Defaults to `false`
+     * @throws {Error}                  Error thrown when no message has been provided
+     * @return {Boolean}                Returns true when the notification has been shown
      */
     var notification = exports.notification = function(title, message, type, id, sticky) {
         if (!message) {
@@ -317,7 +318,7 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
         // Show the notification
         $notificationContainer.notify({
             'fadeOut': {
-                'enabled': sticky ? false : true,
+                'enabled': sticky,
                 'delay': 5000
             },
             'type': type ? type : 'success',
@@ -334,6 +335,7 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
         }, 10);
 
         // Fade out and remove the container after 5 seconds if it's not marked as sticky
+        /* istanbul ignore next */
         var fadeTimeout = setTimeout(function() {
             if (!sticky) {
                 $notification.addClass('gh-notification-fade');
@@ -341,6 +343,7 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
         }, 5000);
 
         // Close the notification when the 'X' is clicked
+        /* istanbul ignore next */
         $('a.close', $notificationContainer).off('click').on('click', function(ev) {
             // Add the fade animation to remove the popover from view
             $(this).closest('.alert').addClass('gh-notification-fade');
@@ -456,144 +459,6 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
     googleAnalytics();
 
 
-    /////////////
-    //  STATE  //
-    /////////////
-
-    /**
-     * Refresh the state by triggering the statechange event without making modifications
-     */
-    var refreshState = exports.refreshState = function() {
-        History.Adapter.trigger(window, 'statechange');
-    };
-
-    /**
-     * Add a key/value pair to the URL state
-     *
-     * @param {Object}    toAdd        The key of the state parameter to set
-     * @param {Boolean}   [replace]    Whether to replace the state or push a new one in. Setting to `true` is useful when the state needs to be updated but no history entry should be created. Defaults to `false`
-     */
-    var addToState = exports.addToState = function(toAdd, replace) {
-        // Construct an array to create the state string from
-        var stateString = [];
-        // Whether or not the key/value pair overrides an already existing state property
-        var override = false;
-        // Merge the current history with the arguments to add to it
-        var currentState = _.extend(History.getState().data, toAdd);
-
-        // For each entry, add it to the stateString
-        _.each(currentState, function(value, key) {
-            stateString.push(key + '=' + value);
-        });
-
-        // Create the URL to set the state to
-        var url = '/?' + stateString.join('&');
-        // If the admin UI is loaded, prepend '/admin/?'
-        if ($('body').data('isadminui')) {
-            url = '/admin' + url;
-        }
-
-        // Clear the queue
-        History.clearQueue();
-
-        if (replace) {
-            // Replace with the new state
-            History.replaceState(currentState, $('title').text(), url);
-        } else {
-            // Push the new state
-            History.pushState(currentState, $('title').text(), url);
-        }
-    };
-
-    /**
-     * Remove one or more keys from the state
-     *
-     * @param  {String[]}    keys    Array of keys to remove from the state
-     */
-    var removeFromState = exports.removeFromState = function(keys) {
-        // Construct an array to create the state string from
-        var stateString = [];
-        // Get the current history state to work with
-        var currentState = History.getState();
-        // Cache the state data object to set
-        var stateData = {};
-
-        // If the state is already empty there is nothing to do
-        if (_.isEmpty(currentState.data)) {
-            return;
-        }
-
-        // Loop over each data entry in the state and remove the keys that match
-        _.each(currentState.data, function(value, key) {
-            // Remove the key from the state, if it's matched, by not adding it to the
-            // updated state object
-            if (_.indexOf(keys, key) === -1) {
-                stateString.push(key + '=' + value);
-                stateData[key] = value;
-            }
-        });
-
-        // Create the URL to set the state to
-        var url = '/?' + stateString.join('&');
-        // If the admin UI is loaded, prepend '/admin/?'
-        if ($('body').data('isadminui')) {
-            url = '/admin' + url;
-        }
-
-        // Clear the queue
-        History.clearQueue();
-
-        // Replace the state data
-        History.replaceState(stateData, $('title').text(), url);
-    };
-
-    /**
-     * Set the state data. This is useful in functions that are using the data to determine what to add or remove
-     *
-     */
-    var setStateData = exports.setStateData = function() {
-        // Parse the URL that's in the History state.
-        // The expected URL structure is `[/admin]/?tripos=123&part=234&module=567&series=890`
-        var stateString = History.getState().cleanUrl.split('?');
-
-        // The hostname is included in the stateString Array; if it has more than one item in it that means
-        // there's some state handling to be done.
-        if (stateString.length > 1) {
-            // Cache the state data object to set
-            var stateData = {};
-
-            // Drop the hostname from the Array to only keep the hash
-            stateString = stateString.pop();
-
-            // Split the hash into an Array
-            stateString = stateString.split('&');
-
-            // For each key/value pair in the Array, assign it to the new state object
-            _.each(stateString, function(s) {
-                if (s) {
-                    // Split the string into a key and value
-                    s = s.split('=');
-                    // Add the key/value pair to the state object
-                    stateData[s[0]] = parseInt(s[1], 10);
-                }
-            });
-
-            // Create the URL to set the state to
-            var url = '/?' + stateString.join('&');
-            // If the admin UI is loaded, prepend '/admin/?'
-            if ($('body').data('isadminui')) {
-                url = '/admin' + url;
-            }
-
-            // Clear the queue
-            History.clearQueue();
-
-            // Replace the state data
-            History.replaceState(stateData, $('title').text(), url);
-        }
-    };
-
-
     //////////////////////
     //  INITIALISATION  //
     //////////////////////
@@ -607,6 +472,7 @@ define(['exports', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], f
 
         // Gather all the specific funtionality classes
         var utilClasses = [
+            state,
             templates,
             time
         ];

--- a/shared/gh/js/utils/gh.utils.state.js
+++ b/shared/gh/js/utils/gh.utils.state.js
@@ -1,0 +1,153 @@
+/*!
+ * Copyright 2015 Digital Services, University of Cambridge Licensed
+ * under the Educational Community License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['exports'], function(exports) {
+
+    /**
+     * Refresh the state by triggering the statechange event without making modifications
+     */
+    /* istanbul ignore next */
+    var refreshState = exports.refreshState = function() {
+        History.Adapter.trigger(window, 'statechange');
+    };
+
+    /**
+     * Add a key/value pair to the URL state
+     *
+     * @param {Object}    toAdd        The key of the state parameter to set
+     * @param {Boolean}   [replace]    Whether to replace the state or push a new one in. Setting to `true` is useful when the state needs to be updated but no history entry should be created. Defaults to `false`
+     */
+    /* istanbul ignore next */
+    var addToState = exports.addToState = function(toAdd, replace) {
+        // Construct an array to create the state string from
+        var stateString = [];
+        // Whether or not the key/value pair overrides an already existing state property
+        var override = false;
+        // Merge the current history with the arguments to add to it
+        var currentState = _.extend(History.getState().data, toAdd);
+
+        // For each entry, add it to the stateString
+        _.each(currentState, function(value, key) {
+            stateString.push(key + '=' + value);
+        });
+
+        // Create the URL to set the state to
+        var url = '/?' + stateString.join('&');
+        // If the admin UI is loaded, prepend '/admin/?'
+        if ($('body').data('isadminui')) {
+            url = '/admin' + url;
+        }
+
+        // Clear the queue
+        History.clearQueue();
+
+        if (replace) {
+            // Replace with the new state
+            History.replaceState(currentState, $('title').text(), url);
+        } else {
+            // Push the new state
+            History.pushState(currentState, $('title').text(), url);
+        }
+    };
+
+    /**
+     * Remove one or more keys from the state
+     *
+     * @param  {String[]}    keys    Array of keys to remove from the state
+     */
+    /* istanbul ignore next */
+    var removeFromState = exports.removeFromState = function(keys) {
+        // Construct an array to create the state string from
+        var stateString = [];
+        // Get the current history state to work with
+        var currentState = History.getState();
+        // Cache the state data object to set
+        var stateData = {};
+
+        // If the state is already empty there is nothing to do
+        if (_.isEmpty(currentState.data)) {
+            return;
+        }
+
+        // Loop over each data entry in the state and remove the keys that match
+        _.each(currentState.data, function(value, key) {
+            // Remove the key from the state, if it's matched, by not adding it to the
+            // updated state object
+            if (_.indexOf(keys, key) === -1) {
+                stateString.push(key + '=' + value);
+                stateData[key] = value;
+            }
+        });
+
+        // Create the URL to set the state to
+        var url = '/?' + stateString.join('&');
+        // If the admin UI is loaded, prepend '/admin/?'
+        if ($('body').data('isadminui')) {
+            url = '/admin' + url;
+        }
+
+        // Clear the queue
+        History.clearQueue();
+
+        // Replace the state data
+        History.replaceState(stateData, $('title').text(), url);
+    };
+
+    /**
+     * Set the state data. This is useful in functions that are using the data to determine what to add or remove
+     */
+    /* istanbul ignore next */
+    var setStateData = exports.setStateData = function() {
+        // Parse the URL that's in the History state.
+        // The expected URL structure is `[/admin]/?tripos=123&part=234&module=567&series=890`
+        var stateString = History.getState().cleanUrl.split('?');
+
+        // The hostname is included in the stateString Array; if it has more than one item in it that means
+        // there's some state handling to be done.
+        if (stateString.length > 1) {
+            // Cache the state data object to set
+            var stateData = {};
+
+            // Drop the hostname from the Array to only keep the hash
+            stateString = stateString.pop();
+
+            // Split the hash into an Array
+            stateString = stateString.split('&');
+
+            // For each key/value pair in the Array, assign it to the new state object
+            _.each(stateString, function(s) {
+                if (s) {
+                    // Split the string into a key and value
+                    s = s.split('=');
+                    // Add the key/value pair to the state object
+                    stateData[s[0]] = parseInt(s[1], 10);
+                }
+            });
+
+            // Create the URL to set the state to
+            var url = '/?' + stateString.join('&');
+            // If the admin UI is loaded, prepend '/admin/?'
+            if ($('body').data('isadminui')) {
+                url = '/admin' + url;
+            }
+
+            // Clear the queue
+            History.clearQueue();
+
+            // Replace the state data
+            History.replaceState(stateData, $('title').text(), url);
+        }
+    };
+});

--- a/shared/gh/js/utils/gh.utils.time.js
+++ b/shared/gh/js/utils/gh.utils.time.js
@@ -190,6 +190,7 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
         // week in that term. If it can't be retrieved the date is out of term and 0 should
         // be returned
         var weekNumber = 0;
+        /* istanbul ignore else */
         if (currentTerm) {
             weekNumber = Math.ceil(((date - startDate) / constants.time.PERIODS['week']) - (dayOffset)) + 1;
         }


### PR DESCRIPTION
Since the utilities have been split out into separate files they are no longer covered by the Istanbul code coverage. On line 173 in the Gruntfile.js we need to add `'shared/gh/js/utils/*.js'` and then proceed to bring coverage back up to 100%