### PR TITLE
Improve (batch)edit help messaging 

### DIFF
--- a/shared/gh/js/utils/gh.utils.templates.js
+++ b/shared/gh/js/utils/gh.utils.templates.js
@@ -47,7 +47,8 @@ define(['exports', 'gh.constants'], function(exports, constants) {
         });
 
         // Require all the partial HTML files
-        require(['text!gh/partials/admin-batch-edit.html',
+        require(['text!gh/partials/admin-batch-edit-actions.html',
+                 'text!gh/partials/admin-batch-edit.html',
                  'text!gh/partials/admin-batch-edit-date.html',
                  'text!gh/partials/admin-edit-date-field.html',
                  'text!gh/partials/admin-batch-edit-event-row.html',
@@ -73,9 +74,10 @@ define(['exports', 'gh.constants'], function(exports, constants) {
                  'text!gh/partials/subheader-picker.html',
                  'text!gh/partials/subheader-pickers.html',
                  'text!gh/partials/visibility-button.html',
-                 'text!gh/partials/visibility-modal.html'], function(adminBatchEdit, adminBatchEditDate, adminEditDateField, adminBatchEditEventRow, adminBatchEditEventType, adminBorrowSeriesModuleItem, adminEditDates, adminModuleItem, adminModules, borrowSeriesModal, calendar, deleteSeriesModal, editableParts, emptyTimetable, eventItem, eventPopover, loginForm, loginModal, newModuleModal, newSeries, studentModuleItem, studentModules, subheaderPart, subheaderPicker, subheaderPickers, visibilityButton, visibilityModal) {
+                 'text!gh/partials/visibility-modal.html'], function(adminBatchEditActions, adminBatchEdit, adminBatchEditDate, adminEditDateField, adminBatchEditEventRow, adminBatchEditEventType, adminBorrowSeriesModuleItem, adminEditDates, adminModuleItem, adminModules, borrowSeriesModal, calendar, deleteSeriesModal, editableParts, emptyTimetable, eventItem, eventPopover, loginForm, loginModal, newModuleModal, newSeries, studentModuleItem, studentModules, subheaderPart, subheaderPicker, subheaderPickers, visibilityButton, visibilityModal) {
 
             // Declare all partials which makes them available in every template
+            _.declarePartial('admin-batch-edit-actions', adminBatchEditActions);
             _.declarePartial('admin-batch-edit', adminBatchEdit);
             _.declarePartial('admin-batch-edit-date', adminBatchEditDate);
             _.declarePartial('admin-edit-date-field', adminEditDateField);

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -197,13 +197,16 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
             $row.addClass('gh-event-deleted').fadeOut(200, function() {
                 // Show the empty term description
                 showEmptyTermDescription(termLabel);
+                // Update the footer
+                toggleSubmit();
             });
-            toggleSubmit();
         } else {
             $row.addClass('gh-event-deleted').fadeOut(200, function() {
                 $row.remove();
                 // Show the empty term description
                 showEmptyTermDescription(termLabel);
+                // Update the footer
+                toggleSubmit();
             });
         }
         // Let other components know that an event was deleted
@@ -262,12 +265,23 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
      * @private
      */
     var toggleSubmit = function() {
-        var eventsUpdated = $('.gh-batch-edit-events-container tbody tr.active:not(.gh-event-deleted)').length + $('.gh-batch-edit-events-container tbody tr.gh-event-deleted').length;
+        // Get the number of events that were updated
+        var eventsUpdated = $('.gh-batch-edit-events-container tbody tr.active:not(.gh-event-deleted):not(.gh-new-event-row)').length;
+        // Get the number of events that were created
+        var eventsCreated = $('.gh-batch-edit-events-container tbody tr.gh-new-event-row:not(.gh-event-deleted)').length;
+        // Get the number of events that were deleted
+        var eventsDeleted = $('.gh-batch-edit-events-container tbody tr.gh-event-deleted').length;
 
-        if (eventsUpdated) {
+        // Only toggle and update the footer if events where updated, created or deleted
+        if (eventsUpdated || eventsCreated || eventsDeleted) {
             // Update the count
-            var updatedCountString = eventsUpdated + ' event' + (eventsUpdated === 1 ? '' : 's' ) + ' updated';
-            $('.gh-batch-edit-actions-container #gh-batch-edit-change-summary').text(updatedCountString);
+            utils.renderTemplate($('#gh-batch-edit-actions-template'), {
+                'data': {
+                    'updated': eventsUpdated,
+                    'created': eventsCreated,
+                    'deleted': eventsDeleted
+                }
+            }, $('.gh-batch-edit-actions-container'));
             // Show the save button if events have changed but not submitted
             $('.gh-batch-edit-actions-container').fadeIn(200);
         } else {

--- a/shared/gh/partials/admin-batch-edit-actions.html
+++ b/shared/gh/partials/admin-batch-edit-actions.html
@@ -1,0 +1,17 @@
+<%
+    var updateString = [];
+
+    if (data.updated) {
+        updateString.push(data.updated + ' event' + (data.updated === 1 ? '' : 's' ) + ' changed');
+    }
+    if (data.created) {
+        updateString.push('<span class="text-success">' + data.created + ' event' + (data.created === 1 ? '' : 's' ) + ' added</span>');
+    }
+    if (data.deleted) {
+        updateString.push('<span class="text-danger">' + data.deleted + ' event' + (data.deleted === 1 ? '' : 's' ) + ' deleted</span>');
+    }
+%>
+
+<p id="gh-batch-edit-change-summary" class="pull-left"><%= updateString.join(', ') %></p>
+<button type="button" id="gh-batch-edit-submit" class="btn btn-default pull-right"><i class="fa fa-check"></i> Save</button>
+<button type="button" id="gh-batch-edit-cancel" class="btn btn-link pull-right">Cancel</button>

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -110,11 +110,11 @@
                 <% }); %>
             </div>
 
-            <div class="gh-batch-edit-actions-container" style="display: none;">
-                <p id="gh-batch-edit-change-summary" class="pull-left"></p>
-                <button type="button" id="gh-batch-edit-submit" class="btn btn-default pull-right"><i class="fa fa-check"></i> Save</button>
-                <button type="button" id="gh-batch-edit-cancel" class="btn btn-link pull-right">Cancel</button>
-            </div>
+            <div class="gh-batch-edit-actions-container" style="display: none;"><!-- --></div>
+            <!-- Footer actions template -->
+            <script id="gh-batch-edit-actions-template" type="text/template">
+                <%= _.partial('admin-batch-edit-actions', {'data': data}, false) %>
+            </script>
         </div>
 
         <div id="gh-batch-calendar-view" class="tab-pane" role="tabpanel">


### PR DESCRIPTION
At minimum we should change the copy to:
"{{event_count}} events changed"

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6574523/d3ff01a6-c71d-11e4-8a42-661823e445f8.png)

As a stretch goal, we should give more information:

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6574556/3c3b07d8-c71e-11e4-87aa-abb3aa753be5.png)