### PR TITLE
Tone back OT event styling

### DIFF
--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -331,17 +331,13 @@
 }
 
 /* Terms */
-#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot tr {
-    background-color: #F7F7F7;
-}
-
-#gh-batch-edit-term-container .gh-batch-edit-events-container:not(.gh-ot) + .gh-ot {
-    border-top-color: #DDD;
-}
-
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr.danger.gh-fade td,
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr.success.gh-fade td {
     background-color: #FFF !important;
+}
+
+#gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot .table > tbody > tr > td {
+    border-top-color: #B0B0B0;
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .gh-batch-edit-events-container-empty {

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -74,19 +74,19 @@
                             <thead>
                                 <tr>
                                     <th>
-                                        <div class="checkbox">
-                                            <label>
-                                                <input type="checkbox" class="gh-select-all"> <%- term.name %>
-                                            </label>
-                                        </div>
+                                        <% if (term.name !== 'OT') { %>
+                                            <div class="checkbox">
+                                                <label>
+                                                    <input type="checkbox" class="gh-select-all"> <%- term.name %>
+                                                </label>
+                                            </div>
+                                        <% } %>
                                     </th>
-                                    <th></th>
-                                    <th></th>
-                                    <th></th>
-                                    <th></th>
-                                    <th></th>
+                                    <th colspan="5"></th>
                                     <th>
-                                        <button type="button" class="btn btn-default pull-right gh-btn-secondary gh-new-event"><i class="fa fa-plus-square"></i> Add event</button>
+                                        <% if (term.name !== 'OT') { %>
+                                            <button type="button" class="btn btn-default pull-right gh-btn-secondary gh-new-event"><i class="fa fa-plus-square"></i> Add event</button>
+                                        <% } %>
                                     </th>
                                 </tr>
                             </thead>


### PR DESCRIPTION
With the empty event state visuals in, it will make more sense to tone back the styling of OT events, to reduce visual complexity on the event listing page:

* [x] Remove the grey shading from OT events
* [x] Remove the hidden checkbox and button in the OT event table's <thead>
* [x] Set top margin of OT event to: #B0B0B0

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6596249/51594982-c7ea-11e4-9f3d-da02782de942.png)
