### PR TITLE
Batch editor follow up issues

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -407,7 +407,7 @@
 #gh-batch-edit-header input[type="text"],
 #gh-batch-edit-header select {
     font-weight: 400;
-    height: 32px !important;
+    height: 33px !important;
     padding-left: 6px;
     padding-right: 6px;
 }
@@ -423,7 +423,7 @@
 
 #gh-batch-edit-header .table thead tr th:nth-child(3),
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th:nth-child(3) {
-    width: 170px;
+    width: 180px;
 }
 
 #gh-batch-edit-header .table thead tr th:nth-child(4),
@@ -444,7 +444,7 @@
 }
 
 #gh-batch-edit-header th > * {
-    height: 32px;
+    height: 33px;
     padding: 6px 12px;
     width: 100%;
 }
@@ -458,11 +458,6 @@
 
 #gh-batch-edit-header .gh-batch-edit-header-description {
     vertical-align: middle;
-}
-
-#gh-batch-edit-header.gh-batch-edit-time-open {
-    height: 50px;
-    padding-bottom: 50px;
 }
 
 #gh-batch-edit-header.gh-batch-edit-time-open #gh-batch-edit-time {
@@ -528,14 +523,14 @@
     min-height: 36px;
     min-width: 62px;
     overflow: hidden;
-    padding: 0;
+    padding: 1px 4px 0;
     vertical-align: middle;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox label {
     font-size: 18px;
     font-weight: 400;
-    padding: 3px 5px 0 5px;
+    padding: 5px 4px 2px;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox label i.fa-square-o,
@@ -561,10 +556,11 @@
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox.gh-batch-edit-date-picker-selected {
     border-style: solid;
     border-width: 2px;
+    padding: 0 0 0 2px;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox.gh-batch-edit-date-picker-selected label {
-    padding: 4px 12px 0 13px;
+    padding: 4px 4px 0;
 }
 
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-picker-container .checkbox.gh-batch-edit-date-picker-selected label i.fa-check-square-o {
@@ -577,7 +573,7 @@
     display: block;
 }
 
-#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-day-picker {
+#gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-day-picker {
     width: 120px;
 }
 
@@ -585,7 +581,7 @@
     height: 30px;
 }
 
-#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-day-picker,
+#gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-day-picker,
 #gh-batch-edit-container .gh-batch-edit-time-picker select.form-control {
     font-size: 16px;
     font-weight: 400;
@@ -596,15 +592,15 @@
     width: 50px;
 }
 
-#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-date-start {
+#gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-date-start {
     margin: 0 0 7px 17px;
 }
 
-#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-date-end {
+#gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-date-end {
     margin: 0 0 7px 5px;
 }
 
-#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-date-to {
+#gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-date-to {
     margin: 5px 0 0 5px;
 }
 
@@ -1190,12 +1186,10 @@ ul.as-selections li.as-selection-item {
     width: 100%;
 }
 
-.as-selections .as-original input {
+#gh-batch-edit-header .as-selections .as-original input[type="text"] {
     border: none !important;
-    border-top-style: solid !important;
-    border-top-width: 1px !important;
     font-size: 15px !important;
-    height: 37px !important;
+    height: 31px !important;
     padding: 0 10px;
     width: 100% !important;
 }
@@ -1212,6 +1206,7 @@ ul.as-selections li.as-selection-item {
 
 .as-results {
     font-weight: 200;
+    padding: 0 !important;
     position: absolute;
 }
 

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -296,7 +296,7 @@
     border-color: #62326E;
 }
 
-#gh-batch-edit-container .gh-batch-edit-time-picker #gh-batch-edit-day-picker,
+#gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-day-picker,
 #gh-batch-edit-container .gh-batch-edit-time-picker select.form-control {
     color: #171717;
 }

--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -57,6 +57,18 @@ label {
     font-weight: 600;
 }
 
+input,
+textarea {
+    border-style: solid;
+    border-width: 1px;
+}
+
+input[disabled],
+select[disabled],
+.as-selections.gh-disabled {
+    border-style: solid;
+    border-width: 1px;
+}
 
 /**********/
 /* LAYOUT */

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -43,8 +43,7 @@ select[disabled],
 }
 
 a,
-.btn-link,
-.btn-link i {
+.btn-link {
     color: #127077;
 }
 
@@ -195,6 +194,12 @@ ul.nav-tabs li.active {
 .btn-default.gh-btn-tertiary:active {
     background-color: #2A2A2A;
     border-color: #2A2A2A;
+}
+
+/* Link buttons */
+
+.btn-link i {
+    color: #171717;
 }
 
 
@@ -446,6 +451,10 @@ tbody .fc-sun {
 
 #gh-calendar-view #gh-export-container #gh-export-main #gh-export-subscribe:hover {
     background-color: #127077;
+}
+
+#gh-calendar-view #gh-export-container #gh-export-collapsed-other-toggle.btn-link i {
+    color: #127077;
 }
 
 #gh-calendar-view #gh-export-container #gh-export-main ul li i {

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -22,8 +22,16 @@ h1, h2, h3, h4, h5 {
     color: #171717;
 }
 
-input {
+input,
+textarea {
+    border-color: #CCC;
     color: #171717 !important;
+}
+
+input[disabled],
+select[disabled],
+.as-selections.gh-disabled {
+    border-color: #EEE !important;
 }
 
 #gh-page-container #gh-subheader h1,

--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -163,7 +163,6 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
      * added again unless `forceAdd` has been set to `true`
      *
      * @param {Boolean}    [forceAdd]    Whether to force adding another day. Defaults to `false`
-     * 
      * @private
      */
     var addAnotherEvent = function(forceAdd) {

--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -58,7 +58,7 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
         // Get the unique days in the week to render time pickers for
         var daysInUse = getDaysInUse($rows);
         // Render the batch date editor if at least one week was selected that isn't out of term
-        if (weeksInUse.length && termsInUse.length) {
+        if (termsInUse.length) {
             renderBatchDate(maxNumberOfWeeks, weeksInUse, termsInUse, daysInUse);
         }
     };
@@ -92,14 +92,81 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
     };
 
     /**
-     * Add another day to the terms based on the selection of weeks. If a day has already been added it won't be
+     * Add another day to the terms
+     */
+    var addAnotherDay = function() {
+        // Default the container to look for selected weeks in
+        var $weeks = $('#gh-batch-edit-date-picker input:checked');
+        // Get the days in use by the batch date pickers
+        var $days = $('.gh-batch-edit-time-picker');
+        // Array to keep track of available days
+        var days = [0, 1, 2, 3, 4, 5, 6];
+
+        // Remove all used days from the available days Array
+        _.each($days, function($day) {
+            var usedday = parseInt($($day).find('.gh-batch-edit-day-picker').val(), 10);
+            days.splice(_.indexOf(days, usedday), 1);
+        });
+
+        // For each selected term, add another day
+        _.each($('#gh-batch-edit-date-picker-container').data('terms').split(','), function(termName) {
+            // For each selected week, add another day
+            _.each($weeks, function(chk) {
+                // If the term is empty, add another day on the first day of the week
+                if (!days.length) {
+                    return;
+                }
+
+                // Get the week number
+                var eventWeek = parseInt(chk.value, 10);
+
+                // Get the day number
+                var eventDay = days[0];
+
+                // Get the date by week and day
+                var dateByWeekAndDay = gh.utils.getDateByWeekAndDay(termName, eventWeek, eventDay);
+
+                var eventYear = dateByWeekAndDay.getFullYear();
+                var eventMonth = dateByWeekAndDay.getMonth();
+                eventDay = dateByWeekAndDay.getDate();
+                var eventStartHour = 13;
+                var eventStartMinute = 0;
+                var eventEndHour = 14;
+                var eventEndMinute = 0;
+
+                // Create the start date of the event
+                var startDate = moment([eventYear, eventMonth, eventDay, eventStartHour, eventStartMinute, 0, 0]);
+                // Create the end date of the event
+                var endDate = moment([eventYear, eventMonth, eventDay, eventEndHour, eventEndMinute, 0, 0]);
+
+                $(document).trigger('gh.batchedit.addevent', {
+                    'eventContainer': $('.gh-batch-edit-events-container[data-term="' + termName + '"]').find('tbody'),
+                    'eventObj': {
+                        'tempId': gh.utils.generateRandomString(), // The actual ID hasn't been generated yet
+                        'isNew': true, // Used in the template to know this one needs special handling
+                        'selected': true,
+                        'displayName': $('.gh-jeditable-series-title').text(),
+                        'end': gh.utils.convertUnixDatetoISODate(moment(endDate).toISOString()),
+                        'location': '',
+                        'notes': 'Lecture',
+                        'organisers': null,
+                        'start': gh.utils.convertUnixDatetoISODate(moment(startDate).toISOString())
+                    },
+                    'startDate': startDate
+                });
+            });
+        });
+    };
+
+    /**
+     * Add another event to the terms based on the selection of weeks. If the event has already been added it won't be
      * added again unless `forceAdd` has been set to `true`
      *
      * @param {Boolean}    [forceAdd]    Whether to force adding another day. Defaults to `false`
      * 
      * @private
      */
-    var addAnotherDay = function(forceAdd) {
+    var addAnotherEvent = function(forceAdd) {
 
         // Default the container to look for selected weeks in
         var $weeks = $('#gh-batch-edit-date-picker input:checked');
@@ -115,17 +182,17 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
                         // Get the week number
                         var eventWeek = parseInt(chk.value, 10);
                         // Get the day number
-                        var eventDay = parseInt($('#gh-batch-edit-day-picker', $timePickerContainer).val(), 10);
+                        var eventDay = parseInt($('.gh-batch-edit-day-picker', $timePickerContainer).val(), 10);
                         // Get the date by week and day
                         var dateByWeekAndDay = gh.utils.getDateByWeekAndDay(termName, eventWeek, eventDay);
 
                         var eventYear = dateByWeekAndDay.getFullYear();
                         var eventMonth = dateByWeekAndDay.getMonth();
                         eventDay = dateByWeekAndDay.getDate();
-                        var eventStartHour = parseInt($('#gh-batch-edit-hours-start', $timePickerContainer).val(), 10);
-                        var eventStartMinute = parseInt($('#gh-batch-edit-minutes-start', $timePickerContainer).val(), 10);
-                        var eventEndHour = parseInt($('#gh-batch-edit-hours-end', $timePickerContainer).val(), 10);
-                        var eventEndMinute = parseInt($('#gh-batch-edit-minutes-end', $timePickerContainer).val(), 10);
+                        var eventStartHour = parseInt($('.gh-batch-edit-hours-start', $timePickerContainer).val(), 10);
+                        var eventStartMinute = parseInt($('.gh-batch-edit-minutes-start', $timePickerContainer).val(), 10);
+                        var eventEndHour = parseInt($('.gh-batch-edit-hours-end', $timePickerContainer).val(), 10);
+                        var eventEndMinute = parseInt($('.gh-batch-edit-minutes-end', $timePickerContainer).val(), 10);
 
                         // Create the start date of the event
                         var startDate = moment([eventYear, eventMonth, eventDay, eventStartHour, eventStartMinute, 0, 0]);
@@ -260,20 +327,46 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
     };
 
     /**
+     * Delete all selected events that fall on a certain day of the week
+     *
+     * @private
+     */
+    var deleteDay = function() {
+        // Get the day of the week to delete events for
+        var dayToDelete = parseInt($($(this).prevAll('.gh-batch-edit-day-picker')).val(), 10);
+
+        // Loop over the selected events
+        var $rows = $('.gh-batch-edit-events-container tr.info:visible');
+        _.each($rows, function($row) {
+            $row = $($row);
+
+             // Get the date the event starts on
+            var eventStart = new Date($row.find('.gh-event-date').attr('data-start'));
+
+            // If the event falls on the day that needs to be deleted, delete it
+            if (eventStart.getDay() === dayToDelete) {
+                $($row.find('.gh-event-delete button')).click();
+            }
+        });
+    };
+
+    /**
      * Batch edit the time on which events start and finish
      *
      * @private
      */
     var batchEditTime = function() {
+        // Keep track of whether or not the day of the week needs to change
+        var dayChange = $(this).hasClass('gh-batch-edit-day-picker');
         // Get the container in which the edits where made
         var $timeContainer = $($(this).closest('.gh-batch-edit-time-picker'));
         // Get the values that changed
-        var prevEventDay = parseInt($('#gh-batch-edit-day-picker', $timeContainer).attr('data-prev'), 10);
-        var eventDay = parseInt($('#gh-batch-edit-day-picker', $timeContainer).val(), 10);
-        var eventStartHour = parseInt($('#gh-batch-edit-hours-start', $timeContainer).val(), 10);
-        var eventStartMinute = parseInt($('#gh-batch-edit-minutes-start', $timeContainer).val(), 10);
-        var eventEndHour = parseInt($('#gh-batch-edit-hours-end', $timeContainer).val(), 10);
-        var eventEndMinute = parseInt($('#gh-batch-edit-minutes-end', $timeContainer).val(), 10);
+        var prevEventDay = parseInt($('.gh-batch-edit-day-picker', $timeContainer).data('prev'), 10);
+        var eventDay = parseInt($('.gh-batch-edit-day-picker', $timeContainer).val(), 10);
+        var eventStartHour = parseInt($('.gh-batch-edit-hours-start', $timeContainer).val(), 10);
+        var eventStartMinute = parseInt($('.gh-batch-edit-minutes-start', $timeContainer).val(), 10);
+        var eventEndHour = parseInt($('.gh-batch-edit-hours-end', $timeContainer).val(), 10);
+        var eventEndMinute = parseInt($('.gh-batch-edit-minutes-end', $timeContainer).val(), 10);
 
         // Loop over the selected events and change the ones that match the previous eventDay
         // value (assuming it was changed)
@@ -284,7 +377,8 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
             var eventStart = new Date($row.find('.gh-event-date').attr('data-start'));
 
             // Only update the date when the event takes place on the day that was selected in the picker
-            var dayNumberToEdit = prevEventDay || eventDay;
+            var dayNumberToEdit = prevEventDay;
+
             if (eventStart.getDay() === dayNumberToEdit) {
                 // Get the date the event finishes on
                 var eventEnd = new Date($row.find('.gh-event-date').attr('data-end'));
@@ -294,6 +388,13 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
                 var termName = $row.closest('.gh-batch-edit-events-container').attr('data-term');
                 // Get the date the event would be on after the change
                 var newDate = gh.utils.getDateByWeekAndDay(termName, weekInTerm, eventDay);
+
+                // Only update the year/month/day when we change the day
+                if (!dayChange) {
+                    newDate.setFullYear(eventEnd.getFullYear());
+                    newDate.setMonth(eventEnd.getMonth());
+                    newDate.setDate(eventEnd.getDate());
+                }
 
                 // Create the new date for the row
                 eventStart = moment([newDate.getFullYear(), newDate.getMonth(), newDate.getDate(), eventStartHour, eventStartMinute, 0, 0]).toISOString();
@@ -328,7 +429,7 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
             // Add the class
             $(this).closest('.checkbox').addClass('gh-batch-edit-date-picker-selected');
             // Add all events to the associated week
-            addAnotherDay();
+            addAnotherEvent();
         } else {
             // Remove the class
             $(this).closest('.checkbox').removeClass('gh-batch-edit-date-picker-selected');
@@ -391,19 +492,17 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
         $('body').on('focus', '#gh-batch-edit-date-picker-container input', focusEditDateWeeks);
         $('body').on('blur', '#gh-batch-edit-date-picker-container input', blurEditDateWeeks);
 
-        // Time selectors
-        $('body').on('focus click', '#gh-batch-edit-day-picker', function() {
-            $(this).attr('data-prev', $(this).val());
-        });
-        $('body').on('change', '#gh-batch-edit-day-picker', batchEditTime);
-        $('body').on('change', '#gh-batch-edit-hours-start', batchEditTime);
-        $('body').on('change', '#gh-batch-edit-hours-end', batchEditTime);
-        $('body').on('change', '#gh-batch-edit-minutes-start', batchEditTime);
-        $('body').on('change', '#gh-batch-edit-minutes-end', batchEditTime);
+        // Date picker related events
+        $('body').on('change', '.gh-batch-edit-day-picker', batchEditTime);
+        $('body').on('change', '.gh-batch-edit-hours-start', batchEditTime);
+        $('body').on('change', '.gh-batch-edit-hours-end', batchEditTime);
+        $('body').on('change', '.gh-batch-edit-minutes-start', batchEditTime);
+        $('body').on('change', '.gh-batch-edit-minutes-end', batchEditTime);
+        $('body').on('click', '.gh-batch-edit-date-delete', deleteDay);
 
         // Adding a new day
         $('body').on('click', '.gh-batch-edit-date-add-day', function() {
-            addAnotherDay(true);
+            addAnotherDay();
         });
 
         // Removing events

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -155,7 +155,7 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
         // Show the save button
         toggleSubmit();
         // Enable batch editing of dates
-        toggleBatchEditDateEnabled();
+        toggleBatchEditEnabled();
         // Trigger a change event on the newly added row to update the batch edit
         $eventContainer.find('.gh-select-single').trigger('change');
     };
@@ -240,6 +240,8 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
         }
         // Trigger the change event on all checkboxes
         $checkboxes.change();
+        // Enable batch editing of dates
+        toggleBatchEditEnabled();
     };
 
     /**
@@ -253,7 +255,7 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
         } else {
             $(this).closest('tr').removeClass('info');
         }
-        toggleBatchEditDateEnabled();
+        toggleBatchEditEnabled();
     };
 
     /**
@@ -282,12 +284,15 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
      *
      * @private
      */
-    var toggleBatchEditDateEnabled = function() {
-        if ($('.gh-batch-edit-events-container:not(.gh-ot) tbody .gh-select-single:checked').length) {
-            $('#gh-batch-edit-time').removeAttr('disabled');
+    var toggleBatchEditEnabled = function() {
+        if ($('.gh-batch-edit-events-container:not(.gh-ot) tbody .gh-select-single:checked').length ||
+            $('.gh-batch-edit-events-container:not(.gh-ot) thead .gh-select-all:checked').length) {
+            $('input, button, select', $('#gh-batch-edit-header')).removeAttr('disabled');
+            $('.as-selections', $('#gh-batch-edit-header')).removeClass('gh-disabled');
         } else {
             $('#gh-batch-edit-header').removeClass('gh-batch-edit-time-open');
-            $('#gh-batch-edit-time').attr('disabled', 'disabled');
+            $('input, button, select', $('#gh-batch-edit-header')).attr('disabled', 'disabled');
+            $('.as-selections', $('#gh-batch-edit-header')).addClass('gh-disabled');
         }
     };
 

--- a/shared/gh/partials/admin-batch-edit-date.html
+++ b/shared/gh/partials/admin-batch-edit-date.html
@@ -68,7 +68,7 @@
                     <% } %>
                 </select>
             </div>
-            <button class="btn btn-link gh-batch-edit-date-delete"><i class="fa fa-times"></i></button>
+            <button class="btn btn-link gh-batch-edit-date-delete" title="Delete day from selection"><i class="fa fa-times"></i></button>
         </div>
     <% }); %>
     <button type="button" class="btn btn-default gh-btn-secondary gh-batch-edit-date-add-day"><i class="fa fa-plus-square"></i> Add another day</button>

--- a/shared/gh/partials/admin-batch-edit-date.html
+++ b/shared/gh/partials/admin-batch-edit-date.html
@@ -34,40 +34,41 @@
     </div>
     <% _.each(daysInUse, function(dayInUse, index) { %>
         <div class="form-inline gh-batch-edit-time-picker">
-            <select id="gh-batch-edit-day-picker" class="pull-left form-control">
+            <select class="pull-left form-control gh-batch-edit-day-picker" data-prev="<%- index %>">
                 <option value="4" <% if (parseInt(index, 10) === 4) { %> selected="true" <% } %>>Thursdays</option>
                 <option value="5" <% if (parseInt(index, 10) === 5) { %> selected="true" <% } %>>Fridays</option>
-                <option value="5" <% if (parseInt(index, 10) === 6) { %> selected="true" <% } %>>Saturday</option>
-                <option value="5" <% if (parseInt(index, 10) === 7) { %> selected="true" <% } %>>Sunday</option>
+                <option value="6" <% if (parseInt(index, 10) === 6) { %> selected="true" <% } %>>Saturdays</option>
+                <option value="0" <% if (parseInt(index, 10) === 0) { %> selected="true" <% } %>>Sundays</option>
                 <option value="1" <% if (parseInt(index, 10) === 1) { %> selected="true" <% } %>>Mondays</option>
                 <option value="2" <% if (parseInt(index, 10) === 2) { %> selected="true" <% } %>>Tuesdays</option>
                 <option value="3" <% if (parseInt(index, 10) === 3) { %> selected="true" <% } %>>Wednesdays</option>
             </select>
-            <div id="gh-batch-edit-date-start" class="pull-left">
-                <select id="gh-batch-edit-hours-start" class="form-control gh-batch-edit-hours-picker">
+            <div class="pull-left gh-batch-edit-date-start">
+                <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-start">
                     <% for (var i = 7; i < 20; i += 1) { %>
                         <option value="<%= i %>" <% if (parseInt(dayInUse.startHour, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
                     <% } %>
                 </select>
-                <select id="gh-batch-edit-minutes-start" class="form-control gh-batch-edit-minutes-picker">
+                <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-start">
                     <% for (var i = 0; i < 60; i += 15) { %>
                         <option value="<%= i %>" <% if (parseInt(dayInUse.startMinute, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
                     <% } %>
                 </select>
             </div>
-            <p id="gh-batch-edit-date-to" class="pull-left">to</p>
-            <div id="gh-batch-edit-date-end" class="pull-left">
-                <select id="gh-batch-edit-hours-end" class="form-control gh-batch-edit-hours-picker">
+            <p class="pull-left gh-batch-edit-date-to">to</p>
+            <div class="pull-left gh-batch-edit-date-end">
+                <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-end">
                     <% for (var i = 7; i < 20; i += 1) { %>
                         <option value="<%= i %>" <% if (parseInt(dayInUse.endHour, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
                     <% } %>
                 </select>
-                <select id="gh-batch-edit-minutes-end" class="form-control gh-batch-edit-minutes-picker">
+                <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-end">
                     <% for (var i = 0; i < 60; i += 15) { %>
                         <option value="<%= i %>" <% if (parseInt(dayInUse.endMinute, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
                     <% } %>
                 </select>
             </div>
+            <button class="btn btn-link gh-batch-edit-date-delete"><i class="fa fa-times"></i></button>
         </div>
     <% }); %>
     <button type="button" class="btn btn-default gh-btn-secondary gh-batch-edit-date-add-day"><i class="fa fa-plus-square"></i> Add another day</button>

--- a/shared/gh/partials/admin-batch-edit-event-type.html
+++ b/shared/gh/partials/admin-batch-edit-event-type.html
@@ -1,4 +1,4 @@
-<select id="<%- data.id %>" class="form-control" name="gh-event-type-select">
+<select id="<%- data.id %>" class="form-control" name="gh-event-type-select" disabled>
     <% _.each(data.types, function(value, index) { %>
         <option value="<%- value %>"><%- value %></option>
     <% }) %>

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -40,16 +40,16 @@
                             <tr>
                                 <th>Batch edit:</th>
                                 <th>
-                                    <input type="text" id="gh-batch-edit-title" placeholder="Event titles">
+                                    <input type="text" id="gh-batch-edit-title" placeholder="Event titles" disabled>
                                 </th>
                                 <th>
                                     <button type="button" id="gh-batch-edit-time" class="btn btn-default pull-right" disabled><i class="fa fa-calendar"></i> Dates &amp; times</button>
                                 </th>
                                 <th class="gh-batch-event-organisers">
-                                    <input type="text" id="gh-batch-edit-organisers" placeholder="Organisers">
+                                    <input type="text" id="gh-batch-edit-organisers" placeholder="Organisers" disabled>
                                 </th>
                                 <th>
-                                    <input type="text" id="gh-batch-edit-location" placeholder="Locations">
+                                    <input type="text" id="gh-batch-edit-location" placeholder="Locations" disabled>
                                 </th>
                                 <th>
                                     <%= _.partial('admin-batch-edit-event-type', {


### PR DESCRIPTION
**Styling**
* [x] Selected and unselected weeks have different paddings
* [x] Lecturer component active state  wreaks havoc in other batch edit input fields
![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6594501/cefe7c92-c7d9-11e4-9c51-5858d5813a4c.png)

 * [x] When the batch edit is inactive I can click into lecturer input and get a mis-aligned autocomplete (as per functionality item below, in this state I should't be able to click inside)
![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6594637/e62729b8-c7da-11e4-9f47-6ac3e24b848f.png)

**Functionality**
 * [x] Add another day should add another day line item to the editor
* [x] When selecting an empty term, the batch edit is not available. It should be. 
* [x] When batch edit is inactive, the input fields and dropdowns should be disabled too

Related, on the event list:
 * [x] When am AND pm hours are displayed the date column is too short, so threedots the date/time. We should add a midge more space to the date/time column (take away from the title) to avoid this in all date/time scenarios



