### PR TITLE
Home screen should only show shortcuts to parts I can edit

### DIFF
--- a/shared/gh/partials/editable-parts.html
+++ b/shared/gh/partials/editable-parts.html
@@ -20,8 +20,7 @@
                 <% } %>
                 <p class="gh-part-tripos"><%= part.displayName %></p>
                 <p class="gh-part-part"><%= part.part.displayName %></p>
-                <% var label = (part.part.published) ? 'View' : 'Edit' %>
-                <a href="<%= part.hash %>" class="btn btn-default pull-left gh-part-edit" <% if (part.isEditing && (part.isEditing.id !== gh.data.me.id)) { %> disabled="disabled"<% } %>><%- label %></a>
+                <a href="<%= part.hash %>" class="btn btn-default pull-left gh-part-edit" <% if (part.isEditing && (part.isEditing.id !== gh.data.me.id)) { %> disabled="disabled"<% } %>>Edit</a>
                 <% if (!part.part.published) { %>
                     <span class="gh-part-draft pull-right"><i class="fa fa-eye-slash"></i> Draft</span>
                 <% } %>


### PR DESCRIPTION
![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6636774/2fc97a1c-c96b-11e4-8b53-29aaf1e5848b.png)
