### PR TITLE
Admin UI calendar term selector not working when in OT period

### DIFF
--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -413,7 +413,7 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
         // Get the start date from the current calendar view
         var viewStartDate = calendar.fullCalendar('getDate');
         // Convert the Moment object to a UTC date
-        return gh.utils.convertISODatetoUnixDate(moment(viewStartDate).toISOString());
+        return gh.utils.convertISODatetoUnixDate(moment(viewStartDate).utc().format('YYYY-MM-DD'));
     };
 
     /**


### PR DESCRIPTION
When in a term, all controls work as expected:

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6636611/b8a4a5e8-c969-11e4-9e55-aece461b9c71.png)

But when I navigate outside of term with the week selector, the term selector stops working:

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6636626/e451bf46-c969-11e4-9cca-fe2e21d44aea.png)

This is the error in JS console:

![developer_tools_-_http___ec2-54-155-255-57_eu-west-1_compute_amazonaws_com_admin__tripos_536_part_537_module_538_series_5962](https://cloud.githubusercontent.com/assets/117483/6636649/17ab8958-c96a-11e4-9b32-3ec69932d9ca.png)

This works fine in the student UI.