### PR TITLE
3 minor cosmetic issues

### DIFF
--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -94,7 +94,7 @@
 
         <!-- Tripos help template -->
         <script id="gh-tripos-help-template" type="text/template">
-            <p class="gh-tripos-help">To edit timetable data<br/>choose a tripos from the<br/>dropdown list above,<br/>or select one of the parts on<br/>the right</p>
+            <p class="gh-tripos-help">To edit timetable data<br/>choose a tripos from the<br/>dropdown list above,<br/>or select one of the parts<br/>on the right</p>
         </script>
 
         <!-- Login template -->

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -700,7 +700,6 @@
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox label {
     font-weight: 700;
-    margin-bottom: 7px;
     white-space: nowrap;
 }
 
@@ -720,7 +719,6 @@
 }
 
 #gh-batch-edit-term-container .gh-batch-edit-events-container .gh-jeditable-form input {
-    background-color: transparent;
     border: none;
     height: 31px !important;
     padding: 0 10px;

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -275,7 +275,7 @@
 }
 
 .gh-batch-edit-events-container .gh-jeditable-form input {
-    background-color: transparent;
+    background-color: #FFF;
     border-left-color: #DDD;
     border-right-color: #DDD;
 }


### PR DESCRIPTION
 * [x] Location inline edit text input BG is grey. It should be white.
 * [x] Remove 7px bottom-margin from Term / OT headers
 * [x] Adjust line break in Home screen contextual help, to be "select one of the parts <br> on the right"


![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6636519/b8ea3b7c-c968-11e4-8eee-116612ca36c7.png)

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6636539/f38a5a78-c968-11e4-8af6-48da0293827b.png)

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6636730/cf1d8a28-c96a-11e4-8db0-66218ac82777.png)

