### PR TITLE
Tweak OT event handling & 1 possible OT bug

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -701,6 +701,10 @@
     text-align: center;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container:not(:first-child) .table > thead > tr > th {
+    height: 60px;
+}
+
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox,
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td .checkbox {
     font-size: 16px;
@@ -712,8 +716,11 @@
     white-space: nowrap;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th .checkbox label span {
+    margin-left: 11px;
+}
+
 #gh-batch-edit-term-container .gh-batch-edit-events-container.gh-ot .table > thead > tr > th .checkbox label {
-    cursor: initial;
     white-space: nowrap;
 }
 

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -263,6 +263,10 @@
     background-color: #ECF5F9;
 }
 
+.gh-batch-edit-events-container .table > tbody > tr.gh-not-eligible > .gh-event-date {
+    background-color: #E7E7E7;
+}
+
 .gh-batch-edit-actions-container {
     background: #FFF;
     border-top-color: #BEBEBE;

--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -46,7 +46,9 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
      */
     var buildBatchDateObject = function() {
         // Get the checked events from the batch edit container
-        var $rows = $('.gh-batch-edit-events-container tr.info:visible:not(".gh-event-deleted")');
+        var $selectedRows = $('.gh-batch-edit-events-container tr.info:visible:not(".gh-event-deleted")');
+        // Filter the rows that are eligible for updating
+        var $rows = getEligibleRows($selectedRows);
         // Get the checked terms from the batch edit container
         var $terms = $('.gh-batch-edit-events-container thead .gh-select-all:checked');
         // Get the maximum number of weeks in a term
@@ -69,6 +71,21 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
     ///////////////
 
     /**
+     * Filter the rows that are eligible for batch date/time updating
+     *
+     * @param  {Object[]}    $rows    A collection of selected rows
+     * @return {Object[]}             A filtered collection of rows that are eligible for updating
+     * @private
+     */
+    var getEligibleRows = function($rows) {
+        return _.filter($rows, function($row) {
+            if (!$($row).closest('.gh-batch-edit-events-container').hasClass('gh-ot')) {
+                return $row;
+            }
+        });
+    };
+
+    /**
      * Remove events from a specified week number
      *
      * @param  {Number}    weekNumber    The week number to delete events from
@@ -76,14 +93,18 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
      */
     var removeEventsInWeek = function(weekNumber) {
         // Get the checked events from the batch edit container
-        var $rows = $('.gh-batch-edit-events-container tr.info:visible');
+        var $selectedRows = $('.gh-batch-edit-events-container tr.info:visible');
+        // Filter the rows that are eligible for updating
+        var $rows = getEligibleRows($selectedRows);
+        // Mark the rows that are not eligible for updating
+        $(_.difference($selectedRows, $rows)).addClass('gh-not-eligible');
         // For each row, check if the event is taking place in the week that is to be removed
         _.each($rows, function($row) {
             $row = $($row);
             // Get the start date of the event
             var startDate = gh.utils.convertISODatetoUnixDate($row.find('.gh-event-date').attr('data-start'));
             // Get the week in which the event takes place
-            var dateWeek = gh.utils.getAcademicWeekNumber(startDate);
+            var dateWeek = gh.utils.getAcademicWeekNumber(startDate, true);
             // If the event takes place in the week that needs to be removed, delete it
             if (dateWeek === weekNumber) {
                 $row.addClass('gh-event-deleted').find('.gh-event-delete button').click();
@@ -296,7 +317,7 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
         // Extract the weeks from the batch
         _.each($rows, function(row) {
             var start = gh.utils.convertISODatetoUnixDate(moment($(row).find('.gh-event-date').attr('data-start')).utc().format('YYYY-MM-DD'));
-            weeksInUse.push(gh.utils.getAcademicWeekNumber(start));
+            weeksInUse.push(gh.utils.getAcademicWeekNumber(start, true));
         });
         return _.uniq(weeksInUse);
     };
@@ -369,7 +390,11 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
 
         // Loop over the selected events and change the ones that match the previous eventDay
         // value (assuming it was changed)
-        var $rows = $('.gh-batch-edit-events-container tr.info:visible');
+        var $selectedRows = $('.gh-batch-edit-events-container tr.info:visible');
+        // Filter the rows that are eligible for updating
+        var $rows = getEligibleRows($selectedRows);
+        // Mark the rows that are not eligible for updating
+        $(_.difference($selectedRows, $rows)).addClass('gh-not-eligible');
         _.each($rows, function($row) {
             $row = $($row);
             // Get the date the event starts on

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -386,7 +386,7 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
             // positioned, make the header sticky
             if (windowTop >= headerTop) {
                 // Set the margin of the batch edit container to the height of the sticky header + original margin-top of the event container
-                $('#gh-batch-edit-term-container').css('margin-top', ($('#gh-batch-edit-container').outerHeight() + 60) + 'px');
+                $('#gh-batch-edit-term-container').css('margin-top', ($('#gh-batch-edit-container').outerHeight()) + 'px');
                 // Add the sticky class to the header
                 $('#gh-batch-edit-container').addClass('gh-sticky-header');
             } else {
@@ -960,6 +960,9 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
      * @private
      */
     var submitBatchEdit = function() {
+        // Remove the `gh-not-eligible` class
+        $('.gh-not-eligible').removeClass('gh-not-eligible');
+
         // Disable all elements in the UI to avoid data changing halfway through the update
         disableEnableAll(true);
 

--- a/shared/gh/partials/admin-batch-edit-date.html
+++ b/shared/gh/partials/admin-batch-edit-date.html
@@ -32,6 +32,7 @@
             </label>
         </div>
     </div>
+
     <% _.each(daysInUse, function(dayInUse, index) { %>
         <div class="form-inline gh-batch-edit-time-picker">
             <select class="pull-left form-control gh-batch-edit-day-picker" data-prev="<%- index %>">
@@ -68,7 +69,11 @@
                     <% } %>
                 </select>
             </div>
-            <button class="btn btn-link gh-batch-edit-date-delete" title="Delete day from selection"><i class="fa fa-times"></i></button>
+
+            <!-- Only show the delete button if more than one days are in use -->
+            <% if (_.keys(daysInUse).length > 1) { %>
+                <button class="btn btn-link gh-batch-edit-date-delete" title="Delete day from selection"><i class="fa fa-times"></i></button>
+            <% } %>
         </div>
     <% }); %>
     <button type="button" class="btn btn-default gh-btn-secondary gh-batch-edit-date-add-day"><i class="fa fa-plus-square"></i> Add another day</button>

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -75,17 +75,11 @@
                             <thead>
                                 <tr>
                                     <th>
-                                        <% if (term.name !== 'OT') { %>
-                                            <div class="checkbox">
-                                                <label>
-                                                    <input type="checkbox" class="gh-select-all"> <%- term.name %>
-                                                </label>
-                                            </div>
-                                        <% } else { %>
-                                            <div class="checkbox">
-                                                <label>Out of term</label>
-                                            </div>
-                                        <% } %>
+                                        <div class="checkbox">
+                                            <label>
+                                                <input type="checkbox" class="gh-select-all"><span><% if (term.name !== 'OT') { %><%- term.name %><% } else { %>Out of term<% } %></span>
+                                            </label>
+                                        </div>
                                     </th>
                                     <th></th>
                                     <th></th>


### PR DESCRIPTION
As discussed, let's make it easy for people to edit metadata on OT events as well, and only restrict Date/time batch usage on them:

* [x] Edit all events in the cog menu should select all events including OT events
* [x] Out of term event sections should have their own group/title checkbox to select them
* [x] Disregard any OT events when doing ANY Date/time manipulation with the exception of a regular date/time edit which RESULTS in an OT event (as it is now)
* [x] Bonus: if we can, let's make the ignored OT event's date <td> background color #E7E7E7  so that we give a visual indication of the treatment above
* [x] Remove delete icon from 1st line of day/time entry in the batch editor
**Odd behaviour (ie not sure why this is happening)**
See this series: 
http://ec2-54-155-255-57.eu-west-1.compute.amazonaws.com/admin/?tripos=536&part=537&module=538&series=5962

* [x] Fix week issue
1. Select the "Odd one out" OT event and Michelmas
2. Open Dates & times
3. Tick and untick the "Odd one out" event
At this state ticking and unticking Odd one out will result in W1 tick selector being ticked and unticked. I would expect that it would trigger an OT tickbox just as the "Triggering OT tick" event does.

I am suspecting this is a calendar / term length issue, but I would expect the Odd one out event since it is on the 6th of Oct, before the term start to be really OT and not to behave quantumphysically, being OT-ish :)

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6640684/dda7cd08-c990-11e4-8a77-2b59bf1a2399.png)

