### PR TITLE
No term label for out of term event in date picker

### DIFF
--- a/shared/gh/js/views/gh.datepicker.js
+++ b/shared/gh/js/views/gh.datepicker.js
@@ -280,7 +280,7 @@ define(['gh.core', 'moment', 'clickover', 'jquery-datepicker'], function(gh, mom
         setDatePicker(calendarDate);
 
         // Set the week value
-        var week = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate(startDate));
+        var week = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate(startDate), true);
         $('.popover #gh-module-week').val(week);
 
         // Set the day value


### PR DESCRIPTION
When editing the date of a single out-of-term event, the term label seems to be empty on initialisation

![screen shot 2015-03-16 at 12 00 53](https://cloud.githubusercontent.com/assets/2194396/6665655/e8adafc0-cbd3-11e4-89bb-efe2cd1f8b1f.png)
