### PR TITLE
Adjust click area for series title inline edit

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -396,10 +396,15 @@
 
 #gh-batch-edit-container h1 {
     cursor: pointer;
+    display: inline-block;
     font-size: 25px;
     font-weight: 400;
     height: 40px;
     padding-top: 7px;
+}
+
+#gh-batch-edit-container h1.editing {
+    display: block;
     width: 80%;
 }
 

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -399,7 +399,8 @@
     display: inline-block;
     font-size: 25px;
     font-weight: 400;
-    height: 40px;
+    max-width: 80%;
+    min-height: 40px;
     padding-top: 7px;
 }
 

--- a/shared/gh/js/gh.bootstrap.js
+++ b/shared/gh/js/gh.bootstrap.js
@@ -74,6 +74,7 @@ requirejs.config({
         'gh.admin-edit-organiser': 'gh/js/views/gh.admin-edit-organiser',
         'gh.admin-event-type-select': 'gh/js/views/gh.admin-event-type-select',
         'gh.admin-listview': 'gh/js/views/gh.admin-listview',
+        'gh.admin-series-title': 'gh/js/views/gh.admin-series-title',
         'gh.borrow-series': 'gh/js/views/gh.borrow-series',
         'gh.calendar': 'gh/js/views/gh.calendar',
         'gh.datepicker': 'gh/js/views/gh.datepicker',

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admin-event-type-select', 'gh.datepicker', 'gh.admin-batch-edit-date', 'gh.admin-batch-edit-organiser', 'gh.admin-edit-organiser', 'gh.delete-series'], function(gh, constants, utils, moment) {
+define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admin-event-type-select', 'gh.admin-series-title', 'gh.datepicker', 'gh.admin-batch-edit-date', 'gh.admin-batch-edit-organiser', 'gh.admin-edit-organiser', 'gh.delete-series'], function(gh, constants, utils, moment) {
 
     // Object used to cache the triposData
     var triposData = null;
@@ -516,6 +516,10 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
      * @private
      */
     var editableSeriesTitleSubmitted = function(value, editableField) {
+
+        // Remove the editing class from the jeditable input field
+        $('h1.editing').removeClass('editing');
+
         // Get the value
         value = $.trim(value);
         // If no value has been entered, we fall back to the previous value
@@ -633,14 +637,16 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
      */
     var setUpJEditable = function() {
 
-        // Apply jEditable to the series title
+        // Apply jEditable to the series title. (custom plugin)
         $('.gh-jeditable-series-title').editable(editableSeriesTitleSubmitted, {
             'cssclass': 'gh-jeditable-form gh-jeditable-form-with-submit',
+            'disable': false,
             'height': '38px',
             'maxlength': 255,
             'onblur': 'submit',
-            'placeholder': '',
-            'select' : true,
+            'placeholder': 'Click to add a title for this series',
+            'select': true,
+            'type': 'series-title',
             'submit': '<button type="submit" class="btn btn-default">Save</button>'
         });
 
@@ -660,14 +666,14 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
             }
         });
 
-        // Apply jEditable to the event notes
+        // Apply jEditable to the event type. (custom plugin)
         $('.gh-jeditable-events-select').editable(editableEventTypeSubmitted, {
             'cssclass': 'gh-jeditable-form',
+            'disable': false,
             'placeholder': '',
             'select': true,
             'tooltip': 'Click to edit the event type',
             'type': 'event-type-select',
-            'disable': false,
             'callback': function(value, settings) {
                 // Focus the edited field td element after submitting the value
                 // for improved keyboard accessibility

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -518,7 +518,7 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
     var editableSeriesTitleSubmitted = function(value, editableField) {
 
         // Remove the editing class from the jeditable input field
-        $('h1.editing').removeClass('editing');
+        $('.gh-jeditable-series-title.editing').removeClass('editing');
 
         // Get the value
         value = $.trim(value);
@@ -650,7 +650,7 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
             'submit': '<button type="submit" class="btn btn-default">Save</button>',
             'callback': function(value, settings) {
                 // Remove the `editing` class when the input field loses its focus
-                $('h1.editing').removeClass('editing');
+                $('.gh-jeditable-series-title.editing').removeClass('editing');
             }
         });
 

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -647,7 +647,11 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'moment', 'gh.calendar', 'gh.admi
             'placeholder': 'Click to add a title for this series',
             'select': true,
             'type': 'series-title',
-            'submit': '<button type="submit" class="btn btn-default">Save</button>'
+            'submit': '<button type="submit" class="btn btn-default">Save</button>',
+            'callback': function(value, settings) {
+                // Remove the `editing` class when the input field loses its focus
+                $('h1.editing').removeClass('editing');
+            }
         });
 
         // Apply jEditable for inline editing of event rows

--- a/shared/gh/js/views/gh.admin-series-title.js
+++ b/shared/gh/js/views/gh.admin-series-title.js
@@ -1,0 +1,56 @@
+/*!
+ * Copyright 2015 Digital Services, University of Cambridge Licensed
+ * under the Educational Community License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['gh.core', 'jquery.jeditable'], function(gh) {
+
+    // Create a custom jEditable select box
+    $.editable.addInputType('series-title', {
+
+        /**
+         * Create a form element and attach it to the generated form.
+         * The form is available inside the function as variable this.
+         *
+         * @param  {Object}    settings    the jEditable field settings
+         * @param  {String}    original    the containing HTML element
+         * @private
+         */
+        'element' : function(settings, original) {
+            var input = $('<input maxlength="' + settings.maxlength + '" name="value" placeHolder="' + settings.placeholder + '">');
+            $(this).append(input);
+            return(input);
+        },
+
+        /**
+         * Extend the jEditable behaviour with custom logic
+         *
+         * @param  {Object}    settings    the jEditable field settings
+         * @param  {String}    original    the containing HTML element
+         * @private
+         */
+        'plugin': function(settings, original) {
+            // Add an `editing` class when the input field is being focussed
+            $('input', this).on('focus', function() {
+                $(original).addClass('editing');
+            });
+
+            // Remove the `editing` class when the input field loses its focus
+            $('input', this).on('focusout', function() {
+                setTimeout(function() {
+                    $(original).removeClass('editing');
+                }, 750);
+            });
+        }
+    });
+});

--- a/shared/gh/js/views/gh.admin-series-title.js
+++ b/shared/gh/js/views/gh.admin-series-title.js
@@ -44,13 +44,6 @@ define(['gh.core', 'jquery.jeditable'], function(gh) {
             $('input', this).on('focus', function() {
                 $(original).addClass('editing');
             });
-
-            // Remove the `editing` class when the input field loses its focus
-            $('input', this).on('focusout', function() {
-                setTimeout(function() {
-                    $(original).removeClass('editing');
-                }, 750);
-            });
         }
     });
 });


### PR DESCRIPTION
Keep clicking accidentally on the hotspot, with is 80% of the width I think at the monent.

We should optimise this so that the hotspot for invoking the inline edit should only be the length of the title string.

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6638406/ad1be196-c97d-11e4-88bf-0a8b96c286b3.png)
