### PR TITLE
Improve hashchange handling

### DIFF
--- a/shared/gh/js/views/gh.admin-listview.js
+++ b/shared/gh/js/views/gh.admin-listview.js
@@ -26,6 +26,11 @@ define(['gh.core', 'gh.new-module', 'gh.borrow-series', 'gh.new-series'], functi
     var setUpModules = function(ev, data) {
         // Hide the tripos help text
         $('.gh-tripos-help').hide();
+        // Highlight the selected series
+        $('.gh-series-select').removeClass('gh-series-active');
+        $('.list-group-item[data-id="' + History.getState().data.series + '"] .gh-series-select').addClass('gh-series-active');
+        // Make sure its parent is opened
+        $('.list-group-item[data-id="' + History.getState().data.series + '"]').parents('.list-group-item').addClass('gh-list-group-item-open');
     };
 
     /**
@@ -57,7 +62,7 @@ define(['gh.core', 'gh.new-module', 'gh.borrow-series', 'gh.new-series'], functi
         // Select a series in the sidebar
         $('body').on('click', '.gh-series-select', selectSeries);
         // Set up the modules in the sidebar
-        $(document).on('gh.part.selected', setUpModules);
+        $(document).on('gh.part.selected.admin', setUpModules);
     };
 
     addBinding();

--- a/shared/gh/js/views/gh.new-series.js
+++ b/shared/gh/js/views/gh.new-series.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'gh.constants', 'gh.utils', 'gh.api.orgunit', 'gh.api.series'], function(gh, constants, utils, orgunitAPI, seriesAPI) {
+define(['gh.core', 'gh.constants', 'gh.utils', 'gh.api.orgunit', 'gh.api.series', 'gh.api.orgunit'], function(gh, constants, utils, orgunitAPI, seriesAPI, orgUnitAPI) {
 
     /**
      * Cancel the creation of a new series and return to the last state
@@ -53,14 +53,28 @@ define(['gh.core', 'gh.constants', 'gh.utils', 'gh.api.orgunit', 'gh.api.series'
                 if (err) {
                     return utils.notification('Series not created.', 'The series could not be successfully created.', 'error');
                 }
+
                 utils.notification('Series created.', 'The series was successfully created.', 'success');
 
-                // Push the selected module and new series in the URL
-                var moduleId = parentId;
-                var seriesId = series.id;
-                gh.utils.addToState({
-                    'module': moduleId,
-                    'series': seriesId
+                // Retrieve the organisational unit information for the modules
+                orgUnitAPI.getOrgUnits(gh.data.me.AppId, true, null, partId, ['module'], function(err, modules) {
+                    if (err) {
+                        utils.notification('Fetching modules failed.', 'An error occurred while fetching the modules.', 'error');
+                    }
+
+                    // Refresh the modules list
+                    $(document).trigger('gh.listview.refresh', {
+                        'partId': partId,
+                        'modules': modules
+                    });
+
+                    // Push the selected module and new series in the URL
+                    var moduleId = parentId;
+                    var seriesId = series.id;
+                    gh.utils.addToState({
+                        'module': moduleId,
+                        'series': seriesId
+                    });
                 });
             });
         });

--- a/shared/gh/js/views/gh.subheader.js
+++ b/shared/gh/js/views/gh.subheader.js
@@ -17,6 +17,11 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
 
     var triposData = null;
 
+    // Keep track of the previously selected part
+    var prevPartId = null;
+    // Keep track of the modules to avoid having to fetch them over and over again
+    var cachedModules = null;
+
     /**
      * Return to the home page
      *
@@ -42,19 +47,31 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
         // Track the part picker change in GA
         gh.utils.sendTrackingEvent('picker', 'change', 'part picker', partId);
 
-        // Retrieve the organisational unit information for the modules
-        orgunitAPI.getOrgUnits(gh.data.me.AppId, true, null, partId, ['module'], function(err, modules) {
-            if (err) {
-                utils.notification('Fetching modules failed.', 'An error occurred while fetching the modules.', 'error');
-            }
+        // Retrieve the organisational unit information for the modules, only if the previous part is not the same as
+        // the current one OR if the modules list hasn't been rendered
+        if ((prevPartId !== partId) || !$('#gh-modules-container #gh-modules-list-container ul').length) {
+            orgunitAPI.getOrgUnits(gh.data.me.AppId, true, null, partId, ['module'], function(err, modules) {
+                if (err) {
+                    utils.notification('Fetching modules failed.', 'An error occurred while fetching the modules.', 'error');
+                }
 
-            // Trigger an event when a part has been selected, persisting the part ID and the modules
-            $(document).trigger('gh.part.selected', {
-                'partId': partId,
-                'modules': modules,
-                'container': $('#gh-left-container')
+                // Cache the modules for later use
+                cachedModules = modules;
+
+                // Trigger an event when a part has been selected, persisting the part ID and the modules
+                $(document).trigger('gh.part.selected', {
+                    'partId': partId,
+                    'modules': cachedModules,
+                    'container': $('#gh-left-container')
+                });
             });
-        });
+        } else {
+            // Let the admin modules list know that the list was updated
+            $(document).trigger('gh.part.selected.admin');
+        }
+
+        // Update the previously used partId for next time
+        prevPartId = partId;
     };
 
     /**


### PR DESCRIPTION
Minor improvements to the hashchange handling and module list setup in the administration UI.

With this fix no unnecessary requests to get the module list data should be made. It works by caching the partId and modules and only requesting the module list when the partId in the hash changes.