### PR TITLE
Admin UI bug: Calendar term selector not working in OT terms

### DIFF
--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -477,7 +477,7 @@ define(['gh.core', 'moment', 'clickover'], function(gh, moment) {
         var termDates = _.map(terms, function(term) {
             return {
                 'name': term.name,
-                'date': gh.utils.convertISODatetoUnixDate(term[property])
+                'date': gh.utils.convertISODatetoUnixDate(moment(term[property]).utc().format('YYYY-MM-DD'))
             };
         });
 


### PR DESCRIPTION
When the calendar is loaded in OT state (both week and term selector is "Out of term") the term navigation buttons don't work, and the console shows a JS error:
Uncaught Error: An invalid value for date has been provided

Navigating with the week selectors into a timeframe which is not OT, (getting the term selector in Michelmas for example) will make the term selectors to work properly.

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6730479/e98605c4-ce34-11e4-9ffa-7034096e8b62.png)


![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6730500/28c95d3a-ce35-11e4-88b0-fd0e27603845.png)
