### PR TITLE
Bring the styling of the batch edit calendar up to par

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -870,7 +870,11 @@ tr.info .gh-event-delete button {
 }
 
 #gh-batch-calendar-view {
-    padding: 30px 30px 12px;
+    padding: 0;
+}
+
+#gh-batch-calendar-view #gh-calendar-container {
+    margin-top: 60px;
 }
 
 


### PR DESCRIPTION
There is too much padding on the tab content and too little margin-top on the calendar to make it look the same as the student UI.