### PR TITLE
Calendar selection component multiple days highlighted bug

### DIFF
--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -408,11 +408,10 @@ tr.info .gh-event-delete button i {
 }
 
 #gh-edit-dates .ui-datepicker-calendar td.ui-datepicker-today {
-    background-color: #62326E;
+    background-color: #EFF4F2;
 }
 
-#gh-edit-dates .ui-datepicker-calendar td.ui-datepicker-current-day * ,
-#gh-edit-dates .ui-datepicker-calendar td.ui-datepicker-today * {
+#gh-edit-dates .ui-datepicker-calendar td.ui-datepicker-current-day * {
     color: #FFF;
 }
 


### PR DESCRIPTION
On this series:
http://ec2-54-155-255-57.eu-west-1.compute.amazonaws.com/admin/?tripos=651&part=652&module=653&series=1508

I can see 2 days highlighted. 

What is the second one? It seems it is not the term end.

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6729786/df224748-ce2d-11e4-8625-7ed09d7e4cb9.png)




