### PR TITLE
Admin UI: Improve starting state for part selections (Followup)

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -533,6 +533,10 @@ tbody tr:last-child > td.fc-widget-content {
     padding: 0;
 }
 
+.list-group .list-group-item .btn-link {
+    outline: none !important;
+}
+
 .list-group .list-group-item .gh-list-group-item-container {
     width: 100%;
 }


### PR DESCRIPTION
When a series is selected by clicking on an item (both module and series)
- [ ] The focus rectangle should not be displayed for mouse users: idea: remove outline for a:hover, a:active { outline: none; } ?

Optional bonus for brownie points, if relatively trivial:
- [ ] Maintain last loaded series / module state on a per part basis client side, essentially always loading the last used series by default for a given part, enabling "picking it up, where I left it"

This is carried over from https://github.com/CUL-DigitalServices/grasshopper-ui/pull/228