### PR TITLE
Hide add-another-day button

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -536,6 +536,10 @@
     opacity: 1 !important;
 }
 
+.gh-batch-edit-time-open + #gh-batch-edit-date-container #gh-batch-edit-day-picker-container div:nth-child(7) {
+    margin-bottom: 17px;
+}
+
 .gh-batch-edit-time-open + #gh-batch-edit-date-container #gh-batch-edit-day-picker-container div:nth-child(7) + button {
     display: none;
 }

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -536,6 +536,10 @@
     opacity: 1 !important;
 }
 
+.gh-batch-edit-time-open + #gh-batch-edit-date-container #gh-batch-edit-day-picker-container div:nth-child(7) + button {
+    display: none;
+}
+
 #gh-batch-edit-container #gh-batch-edit-date-container #gh-batch-edit-date-term-description {
     float: left;
     margin-top: 20px;

--- a/shared/gh/partials/admin-batch-edit-date.html
+++ b/shared/gh/partials/admin-batch-edit-date.html
@@ -33,48 +33,50 @@
         </div>
     </div>
 
-    <% _.each(daysInUse, function(dayInUse, index) { %>
-        <div class="form-inline gh-batch-edit-time-picker">
-            <select class="pull-left form-control gh-batch-edit-day-picker" data-prev="<%- index %>">
-                <option value="4" <% if (parseInt(index, 10) === 4) { %> selected="true" <% } %>>Thursdays</option>
-                <option value="5" <% if (parseInt(index, 10) === 5) { %> selected="true" <% } %>>Fridays</option>
-                <option value="6" <% if (parseInt(index, 10) === 6) { %> selected="true" <% } %>>Saturdays</option>
-                <option value="0" <% if (parseInt(index, 10) === 0) { %> selected="true" <% } %>>Sundays</option>
-                <option value="1" <% if (parseInt(index, 10) === 1) { %> selected="true" <% } %>>Mondays</option>
-                <option value="2" <% if (parseInt(index, 10) === 2) { %> selected="true" <% } %>>Tuesdays</option>
-                <option value="3" <% if (parseInt(index, 10) === 3) { %> selected="true" <% } %>>Wednesdays</option>
-            </select>
-            <div class="pull-left gh-batch-edit-date-start">
-                <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-start">
-                    <% for (var i = 7; i < 20; i += 1) { %>
-                        <option value="<%= i %>" <% if (parseInt(dayInUse.startHour, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
-                    <% } %>
+    <div id="gh-batch-edit-day-picker-container">
+        <% _.each(daysInUse, function(dayInUse, index) { %>
+            <div class="form-inline gh-batch-edit-time-picker">
+                <select class="pull-left form-control gh-batch-edit-day-picker" data-prev="<%- index %>">
+                    <option value="4" <% if (parseInt(index, 10) === 4) { %> selected="true" <% } %>>Thursdays</option>
+                    <option value="5" <% if (parseInt(index, 10) === 5) { %> selected="true" <% } %>>Fridays</option>
+                    <option value="6" <% if (parseInt(index, 10) === 6) { %> selected="true" <% } %>>Saturdays</option>
+                    <option value="0" <% if (parseInt(index, 10) === 0) { %> selected="true" <% } %>>Sundays</option>
+                    <option value="1" <% if (parseInt(index, 10) === 1) { %> selected="true" <% } %>>Mondays</option>
+                    <option value="2" <% if (parseInt(index, 10) === 2) { %> selected="true" <% } %>>Tuesdays</option>
+                    <option value="3" <% if (parseInt(index, 10) === 3) { %> selected="true" <% } %>>Wednesdays</option>
                 </select>
-                <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-start">
-                    <% for (var i = 0; i < 60; i += 15) { %>
-                        <option value="<%= i %>" <% if (parseInt(dayInUse.startMinute, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
-                    <% } %>
-                </select>
-            </div>
-            <p class="pull-left gh-batch-edit-date-to">to</p>
-            <div class="pull-left gh-batch-edit-date-end">
-                <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-end">
-                    <% for (var i = 7; i < 20; i += 1) { %>
-                        <option value="<%= i %>" <% if (parseInt(dayInUse.endHour, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
-                    <% } %>
-                </select>
-                <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-end">
-                    <% for (var i = 0; i < 60; i += 15) { %>
-                        <option value="<%= i %>" <% if (parseInt(dayInUse.endMinute, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
-                    <% } %>
-                </select>
-            </div>
+                <div class="pull-left gh-batch-edit-date-start">
+                    <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-start">
+                        <% for (var i = 7; i < 20; i += 1) { %>
+                            <option value="<%= i %>" <% if (parseInt(dayInUse.startHour, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
+                        <% } %>
+                    </select>
+                    <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-start">
+                        <% for (var i = 0; i < 60; i += 15) { %>
+                            <option value="<%= i %>" <% if (parseInt(dayInUse.startMinute, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
+                        <% } %>
+                    </select>
+                </div>
+                <p class="pull-left gh-batch-edit-date-to">to</p>
+                <div class="pull-left gh-batch-edit-date-end">
+                    <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-end">
+                        <% for (var i = 7; i < 20; i += 1) { %>
+                            <option value="<%= i %>" <% if (parseInt(dayInUse.endHour, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
+                        <% } %>
+                    </select>
+                    <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-end">
+                        <% for (var i = 0; i < 60; i += 15) { %>
+                            <option value="<%= i %>" <% if (parseInt(dayInUse.endMinute, 10) === i ) { %> selected="true" <% } %>><%- gh.utils.addLeadingZero(i) %></option>
+                        <% } %>
+                    </select>
+                </div>
 
-            <!-- Only show the delete button if more than one days are in use -->
-            <% if (_.keys(daysInUse).length > 1) { %>
-                <button class="btn btn-link gh-batch-edit-date-delete" title="Delete day from selection"><i class="fa fa-times"></i></button>
-            <% } %>
-        </div>
-    <% }); %>
-    <button type="button" class="btn btn-default gh-btn-secondary gh-batch-edit-date-add-day"><i class="fa fa-plus-square"></i> Add another day</button>
+                <!-- Only show the delete button if more than one days are in use -->
+                <% if (_.keys(daysInUse).length > 1) { %>
+                    <button class="btn btn-link gh-batch-edit-date-delete" title="Delete day from selection"><i class="fa fa-times"></i></button>
+                <% } %>
+            </div>
+        <% }); %>
+        <button type="button" class="btn btn-default gh-btn-secondary gh-batch-edit-date-add-day"><i class="fa fa-plus-square"></i> Add another day</button>
+    </div>
 </div>


### PR DESCRIPTION
When all the possible days have been added, the "add another day" button should be hidden since it's not working anyway...

![screen shot 2015-03-23 at 16 07 05](https://cloud.githubusercontent.com/assets/2194396/6784226/69e41dca-d176-11e4-9fcb-bda0286853b1.png)
