### PR TITLE
Modify 'add another day' workflow

### DIFF
--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -200,6 +200,11 @@
             <%= _.partial('visibility-button', {'data': data}) %>
         </script>
 
+        <!-- Add another day selector -->
+        <script id="gh-admin-batch-edit-time-picker" type="text/template">
+            <%= _.partial('admin-batch-edit-time-picker', {'data': data}) %>
+        </script>
+
         <script data-main="/shared/gh/js/gh.bootstrap.js" data-loadmodule="/apps/timetable/admin/ui/js/index.js" src="/shared/vendor/js/require-jquery.js"></script>
     </body>
 </html>

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -626,7 +626,7 @@
 }
 
 #gh-batch-edit-container .gh-batch-edit-time-picker .gh-batch-edit-day-picker {
-    width: 120px;
+    width: 130px;
 }
 
 #gh-batch-edit-container .gh-batch-edit-time-picker select.form-control {

--- a/shared/gh/js/utils/gh.utils.templates.js
+++ b/shared/gh/js/utils/gh.utils.templates.js
@@ -53,6 +53,7 @@ define(['exports', 'gh.constants'], function(exports, constants) {
             'text!gh/partials/admin-batch-edit-date.html',
             'text!gh/partials/admin-batch-edit-event-row.html',
             'text!gh/partials/admin-batch-edit-event-type.html',
+            'text!gh/partials/admin-batch-edit-time-picker.html',
             'text!gh/partials/admin-borrow-series-module-item.html',
             'text!gh/partials/admin-edit-date-field.html',
             'text!gh/partials/admin-edit-dates.html',

--- a/shared/gh/partials/admin-batch-edit-date.html
+++ b/shared/gh/partials/admin-batch-edit-date.html
@@ -34,48 +34,10 @@
     </div>
 
     <div id="gh-batch-edit-day-picker-container">
-        <% _.each(data.daysInUse, function(dayInUse, index) { %>
-            <div class="form-inline gh-batch-edit-time-picker">
-                <select class="pull-left form-control gh-batch-edit-day-picker" data-prev="<%- index %>">
-                    <option value="4" <% if (parseInt(index, 10) === 4) { %> selected="true" <% } %>>Thursdays</option>
-                    <option value="5" <% if (parseInt(index, 10) === 5) { %> selected="true" <% } %>>Fridays</option>
-                    <option value="6" <% if (parseInt(index, 10) === 6) { %> selected="true" <% } %>>Saturdays</option>
-                    <option value="0" <% if (parseInt(index, 10) === 0) { %> selected="true" <% } %>>Sundays</option>
-                    <option value="1" <% if (parseInt(index, 10) === 1) { %> selected="true" <% } %>>Mondays</option>
-                    <option value="2" <% if (parseInt(index, 10) === 2) { %> selected="true" <% } %>>Tuesdays</option>
-                    <option value="3" <% if (parseInt(index, 10) === 3) { %> selected="true" <% } %>>Wednesdays</option>
-                </select>
-                <div class="pull-left gh-batch-edit-date-start">
-                    <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-start">
-                        <% for (var i = 7; i < 20; i += 1) { %>
-                            <option value="<%= i %>" <% if (parseInt(dayInUse.startHour, 10) === i ) { %> selected="true" <% } %>><%- data.gh.utils.addLeadingZero(i) %></option>
-                        <% } %>
-                    </select>
-                    <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-start">
-                        <% for (var i = 0; i < 60; i += 15) { %>
-                            <option value="<%= i %>" <% if (parseInt(dayInUse.startMinute, 10) === i ) { %> selected="true" <% } %>><%- data.gh.utils.addLeadingZero(i) %></option>
-                        <% } %>
-                    </select>
-                </div>
-                <p class="pull-left gh-batch-edit-date-to">to</p>
-                <div class="pull-left gh-batch-edit-date-end">
-                    <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-end">
-                        <% for (var i = 7; i < 20; i += 1) { %>
-                            <option value="<%= i %>" <% if (parseInt(dayInUse.endHour, 10) === i ) { %> selected="true" <% } %>><%- data.gh.utils.addLeadingZero(i) %></option>
-                        <% } %>
-                    </select>
-                    <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-end">
-                        <% for (var i = 0; i < 60; i += 15) { %>
-                            <option value="<%= i %>" <% if (parseInt(dayInUse.endMinute, 10) === i ) { %> selected="true" <% } %>><%- data.gh.utils.addLeadingZero(i) %></option>
-                        <% } %>
-                    </select>
-                </div>
-
-                <!-- Only show the delete button if more than one days are in use -->
-                <% if (_.keys(data.daysInUse).length > 1) { %>
-                    <button class="btn btn-link gh-batch-edit-date-delete" title="Delete day from selection"><i class="fa fa-times"></i></button>
-                <% } %>
-            </div>
+        <% _.each(data.daysInUse, function(dayInUse, dayIndex) { %>
+            <% data.dayInUse = dayInUse %>
+            <% data.dayIndex = dayIndex %>
+            <%= _.partial('admin-batch-edit-time-picker', {'data': data}) %>
         <% }); %>
         <button type="button" class="btn btn-default gh-btn-secondary gh-batch-edit-date-add-day"><i class="fa fa-plus-square"></i> Add another day</button>
     </div>

--- a/shared/gh/partials/admin-batch-edit-time-picker.html
+++ b/shared/gh/partials/admin-batch-edit-time-picker.html
@@ -1,0 +1,44 @@
+<div class="form-inline gh-batch-edit-time-picker">
+    <select class="pull-left form-control gh-batch-edit-day-picker" data-prev="<%- data.dayIndex %>">
+        <% if (parseInt(data.dayIndex, 10) === 7) { %>
+            <option value="7" <% if (parseInt(data.dayIndex, 10) === 7) { %> selected="true" <% } %>>Choose a day</option>
+        <% } %>
+        <option value="4" <% if (parseInt(data.dayIndex, 10) === 4) { %> selected="true" <% } %>>Thursdays</option>
+        <option value="5" <% if (parseInt(data.dayIndex, 10) === 5) { %> selected="true" <% } %>>Fridays</option>
+        <option value="6" <% if (parseInt(data.dayIndex, 10) === 6) { %> selected="true" <% } %>>Saturdays</option>
+        <option value="0" <% if (parseInt(data.dayIndex, 10) === 0) { %> selected="true" <% } %>>Sundays</option>
+        <option value="1" <% if (parseInt(data.dayIndex, 10) === 1) { %> selected="true" <% } %>>Mondays</option>
+        <option value="2" <% if (parseInt(data.dayIndex, 10) === 2) { %> selected="true" <% } %>>Tuesdays</option>
+        <option value="3" <% if (parseInt(data.dayIndex, 10) === 3) { %> selected="true" <% } %>>Wednesdays</option>
+    </select>
+    <div class="pull-left gh-batch-edit-date-start">
+        <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-start">
+            <% for (var i = 7; i < 20; i += 1) { %>
+                <option value="<%= i %>" <% if (parseInt(data.dayInUse.startHour, 10) === i ) { %> selected="true" <% } %>><%- data.gh.utils.addLeadingZero(i) %></option>
+            <% } %>
+        </select>
+        <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-start">
+            <% for (var i = 0; i < 60; i += 15) { %>
+                <option value="<%= i %>" <% if (parseInt(data.dayInUse.startMinute, 10) === i ) { %> selected="true" <% } %>><%- data.gh.utils.addLeadingZero(i) %></option>
+            <% } %>
+        </select>
+    </div>
+    <p class="pull-left gh-batch-edit-date-to">to</p>
+    <div class="pull-left gh-batch-edit-date-end">
+        <select class="form-control gh-batch-edit-hours-picker gh-batch-edit-hours-end">
+            <% for (var i = 7; i < 20; i += 1) { %>
+                <option value="<%= i %>" <% if (parseInt(data.dayInUse.endHour, 10) === i ) { %> selected="true" <% } %>><%- data.gh.utils.addLeadingZero(i) %></option>
+            <% } %>
+        </select>
+        <select class="form-control gh-batch-edit-minutes-picker gh-batch-edit-minutes-end">
+            <% for (var i = 0; i < 60; i += 15) { %>
+                <option value="<%= i %>" <% if (parseInt(data.dayInUse.endMinute, 10) === i ) { %> selected="true" <% } %>><%- data.gh.utils.addLeadingZero(i) %></option>
+            <% } %>
+        </select>
+    </div>
+
+    <!-- Only show the delete button if more than one days are in use -->
+    <% if (_.keys(data.daysInUse).length > 1) { %>
+        <button class="btn btn-link gh-batch-edit-date-delete" title="Delete day from selection"><i class="fa fa-times"></i></button>
+    <% } %>
+</div>


### PR DESCRIPTION
The add another day workflow in the batch date edit header should be modified to:

- When clicking the 'add another day' a new time picker row is rendered below other already set days
- The first item in the day select is 'Choose day'
- When 'Choose day' is replaced with an actual day the events get generated and the batch edit header updated

Setting this to high priority as it came up in a lot of user testing sessions.

![screen shot 2015-03-26 at 09 51 02](https://cloud.githubusercontent.com/assets/218391/6843755/a3697aee-d39d-11e4-90b8-8c75098854a4.png)
