### PR TITLE
Idea: Potential minor tweak might give a good tablet experience

### DIFF
--- a/apps/admin/ui/index.html
+++ b/apps/admin/ui/index.html
@@ -2,7 +2,7 @@
     <head>
         <title>Timetable Global Administration</title>
 
-        <meta name="viewport" content="width=device-width">
+        <meta name="viewport" content="width=device-width" initial-scale="1.0">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 

--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -2,7 +2,7 @@
     <head>
         <title>Timetable Administration</title>
 
-        <meta name="viewport" content="width=device-width">
+        <meta name="viewport" content="width=device-width" initial-scale="1.0">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 

--- a/apps/timetable/ui/index.html
+++ b/apps/timetable/ui/index.html
@@ -2,7 +2,7 @@
     <head>
         <title>My Timetable</title>
 
-        <meta name="viewport" content="width=device-width">
+        <meta name="viewport" content="width=device-width" initial-scale="1.0">
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -38,7 +38,7 @@
 
 #gh-right-container #gh-subheader form {
     margin: 0 0 0 40px;
-    min-width: 960px;
+    min-width: 900px;
     padding: 28px 0 0;
 }
 


### PR DESCRIPTION
We should test this on actual devices and treat this as a low priority issue:

Removing the min-width: 1280px;
Tripos selector width: 38%
Part selector width: 28%

Might give us a decent experience on iPads / Tablets at @1024, which if doesn't take more than a couple of hours work would be worth it I think

(width, scrolling will need additional fixing)



