### PR TITLE
Prevent borrowing from the current module

### DIFF
--- a/shared/gh/js/views/gh.borrow-series.js
+++ b/shared/gh/js/views/gh.borrow-series.js
@@ -69,7 +69,8 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit'], function(gh, constants, or
         // Render the results in the part picker
         gh.utils.renderTemplate($('#gh-borrow-series-part-template'), {
             'data': {
-                'parts': parts
+                'parts': parts,
+                'excludePart': History.getState().data.part
             }
         }, $('#gh-borrow-series-part'));
 

--- a/shared/gh/js/views/gh.subheader.js
+++ b/shared/gh/js/views/gh.subheader.js
@@ -157,7 +157,9 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
         // Massage the data so that courses are linked to their child subjects
         // Render the results in the tripos picker
         gh.utils.renderTemplate($('#gh-subheader-picker-template'), {
-            'data': triposPickerData
+            'data': {
+                'triposPickerData': triposPickerData
+            }
         }, $('#gh-subheader-tripos'));
 
         // Show the subheader tripos picker

--- a/shared/gh/partials/borrow-series-modal.html
+++ b/shared/gh/partials/borrow-series-modal.html
@@ -8,10 +8,10 @@
             <div class="modal-body">
                 <form class="form-horizontal gh-chosen-inverted">
                     <select id="gh-borrow-series-tripos" class="chosen-select" data-placeholder="Choose a Tripos" style="display: none; width: 300px;" tabindex="-1">
-                        <%= _.partial('subheader-picker', {'data': data.triposPickerData}) %>
+                        <%= _.partial('subheader-picker', {'data': data}) %>
                     </select>
                     <select id="gh-borrow-series-part" class="chosen-select" data-placeholder="Choose a part/paper" style="display: none; width: 160px;" tabindex="-1">
-                        <%= _.partial('subheader-part', {'data': data.triposPickerData}) %>
+                        <%= _.partial('subheader-part', {'data': data}) %>
                     </select>
                 </form>
 
@@ -26,7 +26,7 @@
 </div>
 
 <script id="gh-borrow-series-part-template" type="text/template">
-    <%= _.partial('subheader-part', {'data': data.triposPickerData}, false) %>
+    <%= _.partial('subheader-part', {'data': data}, false) %>
 </script>
 
 <script id="gh-borrow-series-modules-template" type="text/template">

--- a/shared/gh/partials/subheader-part.html
+++ b/shared/gh/partials/subheader-part.html
@@ -1,4 +1,8 @@
 <option value=""></option>
 <%_.each(data.parts, function(part) { %>
-    <option value="<%- part.id %>"><%- part.displayName %><% if(!part.published) { %> - Draft<% } %></option>
+    <% if (data.excludePart !== part.id) { %>
+        <option value="<%- part.id %>"><%- part.displayName %><% if(!part.published) { %> - Draft<% } %></option>
+    <% } else { %>
+        <option value="" disabled><%- part.displayName %><% if(!part.published) { %> - Draft<% } %></option>
+    <% } %>
 <% }); %>

--- a/shared/gh/partials/subheader-picker.html
+++ b/shared/gh/partials/subheader-picker.html
@@ -1,5 +1,5 @@
 <option value=""></option>
-<%_.each(data.courses, function(course) { %>
+<%_.each(data.triposPickerData.courses, function(course) { %>
     <% if (course.subjects.length === 0) { %>
         <option value="<%- course.id %>"><%- course.displayName %></option>
     <% } else { %>


### PR DESCRIPTION
e.g.: When attempting to borrow a series **for** Architectural Engineering, if should only be possible to borrow a series **from any** module **except** Architectural Engineering. (The current module should not show up in the borrowing modal)

![screen shot 2015-03-25 at 09 46 41](https://cloud.githubusercontent.com/assets/2194396/6821915/9268233c-d2d3-11e4-8497-62bc8442dc66.png)