### PR TITLE
Student UI copy tweaks 

### DIFF
--- a/apps/timetable/ui/index.html
+++ b/apps/timetable/ui/index.html
@@ -45,7 +45,7 @@
                         <img src="/shared/gh/img/unilogo.png" alt="Cambridge University">
                     </a>
                     <div id="gh-content-description">
-                        <p style="display: none;">Choose a tripos &amp; part<br/> to see available modules</p>
+                        <p style="display: none;">Select your area of study<br/>to see available modules</p>
                     </div>
                 </div>
                 <div id="gh-modules-container"><!-- --></div>

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -845,6 +845,19 @@ tbody tr:last-child > td.fc-widget-content {
     background-image: none;
 }
 
+.chosen-container.chosen-with-drop .chosen-drop,
+.chosen-container.chosen-with-drop .chosen-single {
+    border-style: solid;
+}
+
+.chosen-container.chosen-with-drop .chosen-drop {
+    border-width: 0 1px 1px 1px;
+}
+
+.chosen-container.chosen-with-drop .chosen-single {
+    border-width: 1px 1px 0 1px;
+}
+
 
 /**********/
 /* EVENTS */

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -374,8 +374,29 @@ ul.nav-tabs li.active {
     border-color: #CCC !important;
 }
 
+.chosen-container .chosen-search input::-webkit-input-placeholder {
+   color: #555;
+}
+
+.chosen-container .chosen-search input::-moz-placeholder {  /* Firefox 19+ */
+   color: #555;
+}
+
+.chosen-container .chosen-search input:-ms-input-placeholder {
+   color: #555;
+}
+
+.chosen-container .chosen-results li.no-results {
+    background: none !important;
+}
+
 .chosen-container .chosen-results li.highlighted {
     background-color: #127077;
+}
+
+.chosen-container.chosen-with-drop .chosen-drop,
+.chosen-container.chosen-with-drop .chosen-single {
+    border-color: #DDD !important;
 }
 
 

--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -179,7 +179,7 @@ define(['gh.core', 'gh.constants', 'moment', 'clickover'], function(gh, constant
         // Change the view
         calendar.fullCalendar('changeView', currentView);
         // Set the view mode label
-        $('#gh-switch-view-label').html(getReadableView());
+        $('#gh-switch-view-label').html(getReadableView() + ' view');
         // Set the current day
         setCurrentDay();
         // Set the period label
@@ -316,7 +316,7 @@ define(['gh.core', 'gh.constants', 'moment', 'clickover'], function(gh, constant
             var weekNumber = gh.utils.getAcademicWeekNumber(getCurrentViewDate());
 
             // Set the label
-            label = 'Outside term';
+            label = 'Outside term week';
             if (weekNumber) {
                 label = 'Week ' + weekNumber;
             }

--- a/shared/gh/partials/calendar.html
+++ b/shared/gh/partials/calendar.html
@@ -11,7 +11,7 @@
                     <button id="gh-btn-calendar-print" class="btn btn-default gh-btn-secondary gh-btn-reverse default"><i class="fa fa-print"></i><span> Print</span></button>
                     <button id="gh-btn-calendar-export" class="btn btn-default">
                         <div>
-                            <i class="fa fa-calendar"></i><span> Export to calendar</span>
+                            <i class="fa fa-calendar"></i><span> Subscribe to calendar</span>
                         </div>
                         <div style="display: none;">
                             <i class="fa fa-times-circle"></i><span> Close</span>
@@ -62,19 +62,19 @@
             <ul id="gh-calendar-toolbar-view" class="nav nav-pills pull-right" role="tablist">
                 <li role="presentation" class="dropdown">
                     <button id="gh-switch-view-container" class="btn btn-default pull-right gh-btn-secondary" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                        <span class="sr-only">Week</span>
-                        <span id="gh-switch-view-label">Week</span>
+                        <span class="sr-only">Week view</span>
+                        <span id="gh-switch-view-label">Week view</span>
                         <span class="caret"></span>
                     </button>
                     <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="gh-switch-view-container">
                         <li role="presentation">
-                            <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="agendaWeek" role="menuitem">Week</button>
+                            <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="agendaWeek" role="menuitem">Week view</button>
                         </li>
                         <li role="presentation">
-                            <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="month" role="menuitem">Month</button>
+                            <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="month" role="menuitem">Month view</button>
                         </li>
                         <li role="presentation">
-                            <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="agendaDay" role="menuitem">Day</button>
+                            <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="agendaDay" role="menuitem">Day view</button>
                         </li>
                     </ul>
                 </li>

--- a/shared/gh/partials/student-module-item.html
+++ b/shared/gh/partials/student-module-item.html
@@ -35,7 +35,7 @@
                                     <% } else if (d.metadata.locations.length === 1) { %>
                                         <p class="gh-list-metadata"><%- d.metadata.locations[0] %></p>
                                     <% } else { %>
-                                        <p class="gh-list-metadata no-information">No location information</p>
+                                        <p class="gh-list-metadata no-information">Location not known</p>
                                     <% } %>
                                 <% } %>
                                 <% if (d.metadata.organisers) { %>
@@ -44,7 +44,7 @@
                                     <% } else if (d.metadata.organisers.length === 1) { %>
                                         <p class="gh-list-metadata"><%- d.metadata.organisers[0] %></p>
                                     <% } else { %>
-                                        <p class="gh-list-metadata no-information">No organisers information</p>
+                                        <p class="gh-list-metadata no-information">Lecturer not known</p>
                                     <% } %>
                                 <% } %>
                             <% } %>

--- a/shared/gh/partials/subheader-pickers.html
+++ b/shared/gh/partials/subheader-pickers.html
@@ -1,4 +1,4 @@
 <form class="row form-horizontal pull-left">
-    <select id="gh-subheader-tripos" class="chosen-select" data-placeholder="Choose a Tripos" style="display: none; width: 350px;" tabindex="-1"><!-- --></select>
-    <select id="gh-subheader-part" class="chosen-select" data-placeholder="Choose a part/paper" style="display: none; width: 350px;" tabindex="-1"><!-- --></select>
+    <select id="gh-subheader-tripos" class="chosen-select" data-placeholder="Select your area of study" style="display: none; width: 350px;" tabindex="-1"><!-- --></select>
+    <select id="gh-subheader-part" class="chosen-select" data-placeholder="Choose a part or paper" style="display: none; width: 350px;" tabindex="-1"><!-- --></select>
 </form>


### PR DESCRIPTION
**Copy tweaks in default mode**

* [x] Adjust copy header contextual help copy
* [x] Adjust tripos dropdown placeholder copy
* [x] Add "week" to week selector
* [x] Add "view" to view dropdown
* [x] In part dropdown placeholder text: "Choose a part or paper"

See copy below:
![my_timetable](https://cloud.githubusercontent.com/assets/117483/6896018/87ad8a72-d6de-11e4-904a-2a687a90a32e.png)

**Copy tweaks when modules are loaded**
* [x] Adjust Export calendar button copy
* [x] "Lecturer not known" instead of "No organisers information"

![my_timetable_mar_26_ _apr_1__2015](https://cloud.githubusercontent.com/assets/117483/6896181/7c4e7ba8-d6e0-11e4-8663-b4494a28d4c1.png)

** Style** adjustments

On tripos dropdown:
 * [x] Set border colour to #ddd on both tripos and part dropdown when open
 * [x] Increase selector search placeholder text color to the same as whole dropdown placeholder


