### PR TITLE
Minor batch edit component styling adjustments

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -396,7 +396,7 @@
 /*****************/
 
 #gh-batch-edit-container {
-    padding: 30px 30px 12px;
+    padding: 30px 30px 5px;
     width: 100%;
 }
 
@@ -429,7 +429,7 @@
     display: inline-block;
     font-size: 25px;
     font-weight: 400;
-    margin-bottom: 35px;
+    margin-bottom: 25px;
     max-width: 80%;
     min-height: 40px;
     padding-top: 7px;
@@ -457,6 +457,17 @@
     font-weight: 400;
     margin-left: 3px;
     text-decoration: none;
+}
+
+#gh-batch-edit-header button,
+#gh-batch-edit-header input[type="text"],
+#gh-batch-edit-header select,
+#gh-batch-edit-header ul.as-selections {
+    -webkit-border-radius: 5px;
+       -moz-border-radius: 5px;
+            border-radius: 5px;
+    border-style: solid;
+    border-width: 1px;
 }
 
 #gh-batch-edit-header input[type="text"],

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -460,7 +460,7 @@
 }
 
 #gh-batch-edit-header button,
-#gh-batch-edit-header input[type="text"],
+#gh-batch-edit-header input[type="text"]:not(.as-input),
 #gh-batch-edit-header select,
 #gh-batch-edit-header ul.as-selections {
     -webkit-border-radius: 5px;
@@ -468,6 +468,10 @@
             border-radius: 5px;
     border-style: solid;
     border-width: 1px;
+}
+
+#gh-batch-edit-header ul.as-selections {
+    overflow: hidden !important;
 }
 
 #gh-batch-edit-header input[type="text"],

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -255,6 +255,25 @@
     color: #171717;
 }
 
+#gh-batch-edit-header button:not(:disabled),
+#gh-batch-edit-header input:not(:disabled)[type="text"],
+#gh-batch-edit-header select:not(:disabled),
+#gh-batch-edit-header ul.as-selections:not(.gh-disabled) {
+    border-color: #171717 !important;
+}
+
+#gh-batch-edit-header input:not(:disabled)[type="text"]::-webkit-input-placeholder {
+    color: #555;
+}
+
+#gh-batch-edit-header input:not(:disabled)[type="text"]::-moz-placeholder {
+    color: #555;
+}
+
+#gh-batch-edit-header input:not(:disabled)[type="text"]:-ms-input-placeholder {
+    color: #555;
+}
+
 #gh-batch-edit-container {
     background-color: #FFF;
 }


### PR DESCRIPTION
* [x] On #gh-batch-edit-container: padding: 30px 30px 5px;
* [x] On #gh-batch-edit-container h1: margin-bottom: 25px;
* [x] Set border colors to #171717
* [x] Set border-radius on all elements to 5px
* [x] Not sure if this is possible: increase placeholder text color a bit (more darker, just a tiny bit)

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6926960/eafe09ae-d7e1-11e4-8f12-eca94397cbc7.png)
 