### PR TITLE
Borrowing & publishing from non published parts

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -282,7 +282,7 @@
 }
 
 .list-group .list-group-item .list-group .list-group-item .gh-list-action i.fa-link {
-    padding-right: 0!important;
+    padding: 5px;
 }
 
 .list-group .list-group-item .list-group .list-group-item .gh-list-description {

--- a/apps/timetable/admin/ui/js/index.js
+++ b/apps/timetable/admin/ui/js/index.js
@@ -31,7 +31,7 @@ define(['gh.core', 'gh.constants', 'gh.listview', 'gh.admin-listview', 'gh.admin
     var getTriposData = function() {
 
         // Fetch the triposes
-        gh.utils.getTriposStructure(function(err, data) {
+        gh.utils.getTriposStructure(null, function(err, data) {
             if (err) {
                 return gh.utils.notification('Could not fetch triposes', constants.messaging.default.error, 'error');
             }

--- a/apps/timetable/ui/js/index.js
+++ b/apps/timetable/ui/js/index.js
@@ -184,7 +184,7 @@ define(['gh.core', 'gh.constants', 'gh.subheader', 'gh.calendar', 'gh.student-li
      */
     var fetchTriposData = function(callback) {
         // Fetch the triposes
-        gh.utils.getTriposStructure(function(err, data) {
+        gh.utils.getTriposStructure(null, function(err, data) {
             if (err) {
                 return gh.utils.notification('Could not fetch triposes', constants.messaging.default.error, 'error');
             }

--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -71,9 +71,18 @@ select[disabled],
 }
 
 .gh-disabled {
-    cursor: default !important;
+    cursor: default;
 }
 
+.gh-disabled-overlay {
+    cursor: not-allowed;
+    display: block;
+    height: 100%;
+    opacity: 0.25;
+    position: absolute;
+    top: 0;
+    width: 100%;
+}
 
 /**************/
 /* VALIDATION */

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -17,6 +17,7 @@
     outline: -webkit-focus-ring-color auto 5px;
 }
 
+
 /**********/
 /* HEADER */
 /**********/
@@ -622,7 +623,7 @@ tbody tr:last-child > td.fc-widget-content {
     border-radius: 3px;
     display: block;
     height: 25px;
-    padding: 5px 0 5px;
+    overflow: hidden;
     text-align: center;
     width: 25px;
 }
@@ -710,6 +711,7 @@ tbody tr:last-child > td.fc-widget-content {
 
 .list-group .list-group-item .gh-series-borrowed .fa-link {
     font-weight: 400;
+    padding: 5px;
 }
 
 /* Nested list */
@@ -966,6 +968,10 @@ tbody tr:last-child > td.fc-widget-content {
 
 .gh-student .popover.gh-series-popover.gh-borrowed-popover {
     margin-left: 60px;
+}
+
+.gh-student .popover.gh-series-popover.gh-borrowed-published-popover {
+    margin-left: 5px;
 }
 
 /* Series info popover */

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -666,6 +666,10 @@ tbody tr:last-child > td.fc-widget-content {
     top: 0;
 }
 
+.list-group .list-group-item .gh-list-action .btn-link:disabled {
+    cursor: default !important;
+}
+
 .list-group .list-group-item .gh-list-action .btn-link i {
     font-size: 19px;
     padding: 0;

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -34,6 +34,10 @@ select[disabled],
     border-color: #EEE !important;
 }
 
+.gh-disabled-overlay {
+    background-color: #171717;
+}
+
 #gh-page-container #gh-subheader h1,
 #gh-page-container #gh-subheader h2,
 #gh-page-container #gh-subheader h3,
@@ -560,11 +564,13 @@ tbody .fc-sun {
 
 /* Series info popover */
 
-.popover.gh-borrowed-popover {
+.popover.gh-borrowed-popover,
+.popover.gh-borrowed-published-popover {
     background-color: #D7E0DC;
 }
 
-.popover.gh-borrowed-popover .arrow:after {
+.popover.gh-borrowed-popover .arrow:after,
+.popover.gh-borrowed-published-popover .arrow:after {
     border-right-color: #D7E0DC;
 }
 

--- a/shared/gh/js/gh.bootstrap.js
+++ b/shared/gh/js/gh.bootstrap.js
@@ -65,6 +65,7 @@ requirejs.config({
         // GH utilities
         'gh.utils': 'gh/js/utils/gh.utils',
         'gh.utils.instrumentation': 'gh/js/utils/gh.utils.instrumentation',
+        'gh.utils.orgunits': 'gh/js/utils/gh.utils.orgunits',
         'gh.utils.state': 'gh/js/utils/gh.utils.state',
         'gh.utils.templates': 'gh/js/utils/gh.utils.templates',
         'gh.utils.time': 'gh/js/utils/gh.utils.time',

--- a/shared/gh/js/gh.bootstrap.js
+++ b/shared/gh/js/gh.bootstrap.js
@@ -87,6 +87,8 @@ requirejs.config({
         'gh.new-series': 'gh/js/views/gh.new-series',
         'gh.rename-module': 'gh/js/views/gh.rename-module',
         'gh.series-info': 'gh/js/views/gh.series-info',
+        'gh.series-borrowed-popover': 'gh/js/views/gh.series-borrowed-popover',
+        'gh.series-borrowed-published-popover': 'gh/js/views/gh.series-borrowed-published-popover',
         'gh.student-listview': 'gh/js/views/gh.student-listview',
         'gh.subheader': 'gh/js/views/gh.subheader',
         'gh.video': 'gh/js/views/gh.video',

--- a/shared/gh/js/utils/gh.utils.js
+++ b/shared/gh/js/utils/gh.utils.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['exports', 'gh.utils.instrumentation', 'gh.utils.state', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], function(exports, instrumentation, state, templates, time) {
+define(['exports', 'gh.utils.instrumentation', 'gh.utils.orgunits', 'gh.utils.state', 'gh.utils.templates', 'gh.utils.time', 'bootstrap-notify'], function(exports, instrumentation, orgunits, state, templates, time) {
 
 
     ///////////////
@@ -102,36 +102,6 @@ define(['exports', 'gh.utils.instrumentation', 'gh.utils.state', 'gh.utils.templ
             server.respond();
             server.restore();
         });
-    };
-
-    /**
-     * Sort given objects based on the displayName property.
-     * The list will be ordered from A to Z.
-     *
-     * @see Array#sort
-     */
-    var sortByDisplayName = exports.sortByDisplayName = function(a, b) {
-        if (a.displayName.toLowerCase() < b.displayName.toLowerCase()){
-            return -1;
-        } else if (a.displayName.toLowerCase() > b.displayName.toLowerCase()) {
-            return 1;
-        }
-        return 0;
-    };
-
-    /**
-     * Sort given objects based on the host property.
-     * The list will be ordered from A to Z.
-     *
-     * @see Array#sort
-     */
-    var sortByHost = exports.sortByHost = function(a, b) {
-        if (a.host.toLowerCase() < b.host.toLowerCase()){
-            return -1;
-        } else if (a.host.toLowerCase() > b.host.toLowerCase()) {
-            return 1;
-        }
-        return 0;
     };
 
 
@@ -338,59 +308,6 @@ define(['exports', 'gh.utils.instrumentation', 'gh.utils.state', 'gh.utils.templ
     };
 
 
-    ////////////////
-    //  TRIPOSES  //
-    ////////////////
-
-    /**
-     * Return the tripos structure
-     *
-     * @param  {Function}    callback             Standard callback function
-     * @param  {Object}      callback.err         Error object containing the error code and error message
-     * @param  {Object}      callback.response    The tripos structure
-     */
-    /* istanbul ignore next */
-    var getTriposStructure = exports.getTriposStructure = function(callback) {
-        if (!_.isFunction(callback)) {
-            throw new Error('An invalid value for callback was provided');
-        }
-
-        var core = require('gh.core');
-        var appId = core.data.me && core.data.me.AppId ? core.data.me.AppId : null;
-        require('gh.api.orgunit').getOrgUnits(null, false, true, null, ['course', 'subject', 'part'], function(err, data) {
-            if (err) {
-                return callback(err);
-            }
-
-            var triposData = {
-                'courses': [],
-                'subjects': [],
-                'parts': [],
-                'modules': []
-            };
-
-            triposData.courses = _.filter(data.results, function(course) {
-                return course.type === 'course';
-            });
-
-            triposData.subjects = _.filter(data.results, function(subject) {
-                return subject.type === 'subject';
-            });
-
-            triposData.parts = _.filter(data.results, function(part) {
-                return part.type === 'part';
-            });
-
-            // Sort the data before displaying it
-            triposData.courses.sort(sortByDisplayName);
-            triposData.subjects.sort(sortByDisplayName);
-            triposData.parts.sort(sortByDisplayName);
-
-            return callback(null, triposData);
-        });
-    };
-
-
     //////////////////////
     //  INITIALISATION  //
     //////////////////////
@@ -405,6 +322,7 @@ define(['exports', 'gh.utils.instrumentation', 'gh.utils.state', 'gh.utils.templ
         // Gather all the specific funtionality classes
         var utilClasses = [
             instrumentation,
+            orgunits,
             state,
             templates,
             time

--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -38,6 +38,7 @@ define(['exports'], function(exports) {
 
                     // Add the parent info to the organisational unit, if any
                     var parent = _.find(orgUnitType, function(orgUnit) { return orgUnit.id === serie.borrowedFrom.ParentId; });
+                    /* istanbul ignore next */
                     if (parent) {
                         serie.borrowedFrom.Parent = parent;
                     }
@@ -61,7 +62,7 @@ define(['exports'], function(exports) {
             _.each(_triposData, function(_orgUnitType) {
 
                 // Add the parent info to the organisational unit, if any
-                var parent = _.find(_orgUnitType, function(_el) { return _el.id === orgUnit.ParentId; });
+                var parent = _.find(_orgUnitType, function(_orgUnit) { return _orgUnit.id === orgUnit.ParentId; });
                 if (parent) {
                     orgUnit.Parent = parent;
                 }

--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -1,0 +1,170 @@
+/*!
+ * Copyright 2015 Digital Services, University of Cambridge Licensed
+ * under the Educational Community License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['exports'], function(exports) {
+
+    // Cache the tripos data
+    var _triposData = {};
+
+
+    //////////////
+    //  SERIES  //
+    //////////////
+
+    /**
+     * Decorate a borrowed serie with its parent info
+     *
+     * @param  {Object[]}    series    A collection of series
+     */
+    var decorateBorrowedSeriesWithParentInfo = exports.decorateBorrowedSeriesWithParentInfo = function(series) {
+        _.each(series, function(serie) {
+
+            // Only decorate borrowed series
+            if (serie.borrowedFrom) {
+                _.each(_triposData, function(orgUnitType) {
+
+                    // Add the parent info to the organisational unit, if any
+                    var parent = _.find(orgUnitType, function(orgUnit) { return orgUnit.id === serie.borrowedFrom.ParentId});
+                    if (parent) {
+                        serie.borrowedFrom.Parent = parent;
+                    }
+                });
+            }
+        });
+    };
+
+
+    ////////////////
+    //  TRIPOSES  //
+    ////////////////
+
+    /**
+     * Decorate an organisational unit with its parent info
+     *
+     * @param  {Object}    orgUnit    The organisational unit that needs to be decorated with his parent info
+     * @private
+     */
+    var addParentInfoToOrgUnit = function(orgUnit) {
+        if (orgUnit.ParentId) {
+            _.each(_triposData, function(_orgUnitType) {
+
+                // Add the parent info to the organisational unit, if any
+                var parent = _.find(_orgUnitType, function(_el) { return _el.id === orgUnit.ParentId});
+                if (parent) {
+                    orgUnit.Parent = parent;
+                }
+            });
+        }
+    };
+
+    /**
+     * Return the complete tripos tree
+     *
+     * @return {Object}    Object containing the tripos data
+     */
+    var getTriposData = exports.getTriposData = function() {
+        return _triposData;
+    };
+
+    /**
+     * Return the tripos structure
+     *
+     * @param  {Function}    callback             Standard callback function
+     * @param  {Object}      callback.err         Error object containing the error code and error message
+     * @param  {Object}      callback.response    The tripos structure
+     */
+    /* istanbul ignore next */
+    var getTriposStructure = exports.getTriposStructure = function(callback) {
+        if (!_.isFunction(callback)) {
+            throw new Error('An invalid value for callback was provided');
+        }
+
+        var core = require('gh.core');
+        var appId = core.data.me && core.data.me.AppId ? core.data.me.AppId : null;
+        require('gh.api.orgunit').getOrgUnits(null, false, true, null, ['course', 'subject', 'part'], function(err, data) {
+            if (err) {
+                return callback(err);
+            }
+
+            var orgUnitTypes = {
+                'modules': []
+            };
+
+            orgUnitTypes.courses = _.filter(data.results, function(course) {
+                return course.type === 'course';
+            });
+
+            orgUnitTypes.subjects = _.filter(data.results, function(subject) {
+                return subject.type === 'subject';
+            });
+
+            orgUnitTypes.parts = _.filter(data.results, function(part) {
+                return part.type === 'part';
+            });
+
+            // Sort the data before displaying it
+            orgUnitTypes.courses.sort(sortByDisplayName);
+            orgUnitTypes.subjects.sort(sortByDisplayName);
+            orgUnitTypes.parts.sort(sortByDisplayName);
+
+            // Cache the organisational units
+            _triposData = orgUnitTypes;
+
+            // Add the parent objects to each organistional unit
+            _.each(orgUnitTypes, function(orgUnitType) {
+                _.each(orgUnitType, function(orgUnit) {
+                    addParentInfoToOrgUnit(orgUnit);
+                });
+            });
+
+            return callback(null, getTriposData());
+        });
+    };
+
+
+    /////////////////
+    //  UTILITIES  //
+    /////////////////
+
+    /**
+     * Sort given objects based on the displayName property.
+     * The list will be ordered from A to Z.
+     *
+     * @see Array#sort
+     */
+    var sortByDisplayName = exports.sortByDisplayName = function(a, b) {
+        if (a.displayName.toLowerCase() < b.displayName.toLowerCase()){
+            return -1;
+        } else if (a.displayName.toLowerCase() > b.displayName.toLowerCase()) {
+            return 1;
+        }
+        return 0;
+    };
+
+    /**
+     * Sort given objects based on the host property.
+     * The list will be ordered from A to Z.
+     *
+     * @see Array#sort
+     */
+    var sortByHost = exports.sortByHost = function(a, b) {
+        if (a.host.toLowerCase() < b.host.toLowerCase()){
+            return -1;
+        } else if (a.host.toLowerCase() > b.host.toLowerCase()) {
+            return 1;
+        }
+        return 0;
+    };
+});

--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -54,9 +54,8 @@ define(['exports'], function(exports) {
      * Decorate an organisational unit with its parent info
      *
      * @param  {Object}    orgUnit    The organisational unit that needs to be decorated with his parent info
-     * @private
      */
-    var addParentInfoToOrgUnit = function(orgUnit) {
+    var addParentInfoToOrgUnit = exports.addParentInfoToOrgUnit = function(orgUnit) {
         if (orgUnit.ParentId) {
             _.each(_triposData, function(_orgUnitType) {
 

--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -32,6 +32,7 @@ define(['exports'], function(exports) {
         _.each(series, function(serie) {
 
             // Only decorate borrowed series
+            /* istanbul ignore else */
             if (serie.borrowedFrom) {
                 _.each(_triposData, function(orgUnitType) {
 
@@ -75,15 +76,20 @@ define(['exports'], function(exports) {
      * @param  {Object}      callback.err         Error object containing the error code and error message
      * @param  {Object}      callback.response    The tripos structure
      */
-    /* istanbul ignore next */
-    var getTriposStructure = exports.getTriposStructure = function(callback) {
+    var getTriposStructure = exports.getTriposStructure = function(appId, callback) {
         if (!_.isFunction(callback)) {
             throw new Error('An invalid value for callback was provided');
+        } else if (appId && !_.isNumber(appId)) {
+            throw new Error('An invalid value for appId was provided');
         }
 
         var core = require('gh.core');
-        var appId = core.data.me && core.data.me.AppId ? core.data.me.AppId : null;
-        require('gh.api.orgunit').getOrgUnits(null, false, true, null, ['course', 'subject', 'part'], function(err, data) {
+        /* istanbul ignore next */
+        if (!appId) {
+            appId = core.data.me && core.data.me.AppId ? core.data.me.AppId : null;
+        }
+        /* istanbul ignore next */
+        require('gh.api.orgunit').getOrgUnits(appId, false, true, null, ['course', 'subject', 'part'], function(err, data) {
             if (err) {
                 return callback(err);
             }

--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -24,7 +24,7 @@ define(['exports'], function(exports) {
     //////////////
 
     /**
-     * Decorate a borrowed serie with its parent info
+     * Decorate a borrowed series with its parent info
      *
      * @param  {Object[]}    series    A collection of series
      */
@@ -36,7 +36,7 @@ define(['exports'], function(exports) {
                 _.each(_triposData, function(orgUnitType) {
 
                     // Add the parent info to the organisational unit, if any
-                    var parent = _.find(orgUnitType, function(orgUnit) { return orgUnit.id === serie.borrowedFrom.ParentId});
+                    var parent = _.find(orgUnitType, function(orgUnit) { return orgUnit.id === serie.borrowedFrom.ParentId; });
                     if (parent) {
                         serie.borrowedFrom.Parent = parent;
                     }
@@ -61,21 +61,12 @@ define(['exports'], function(exports) {
             _.each(_triposData, function(_orgUnitType) {
 
                 // Add the parent info to the organisational unit, if any
-                var parent = _.find(_orgUnitType, function(_el) { return _el.id === orgUnit.ParentId});
+                var parent = _.find(_orgUnitType, function(_el) { return _el.id === orgUnit.ParentId; });
                 if (parent) {
                     orgUnit.Parent = parent;
                 }
             });
         }
-    };
-
-    /**
-     * Return the complete tripos tree
-     *
-     * @return {Object}    Object containing the tripos data
-     */
-    var getTriposData = exports.getTriposData = function() {
-        return _triposData;
     };
 
     /**
@@ -129,7 +120,7 @@ define(['exports'], function(exports) {
                 });
             });
 
-            return callback(null, getTriposData());
+            return callback(null, _triposData);
         });
     };
 

--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -37,7 +37,10 @@ define(['exports'], function(exports) {
                 _.each(_triposData, function(orgUnitType) {
 
                     // Add the parent info to the organisational unit, if any
-                    var parent = _.find(orgUnitType, function(orgUnit) { return orgUnit.id === serie.borrowedFrom.ParentId; });
+                    var parent = _.find(orgUnitType, function(orgUnit) {
+                        return orgUnit.id === serie.borrowedFrom.ParentId;
+                    });
+
                     /* istanbul ignore next */
                     if (parent) {
                         serie.borrowedFrom.Parent = parent;
@@ -62,7 +65,10 @@ define(['exports'], function(exports) {
             _.each(_triposData, function(_orgUnitType) {
 
                 // Add the parent info to the organisational unit, if any
-                var parent = _.find(_orgUnitType, function(_orgUnit) { return _orgUnit.id === orgUnit.ParentId; });
+                var parent = _.find(_orgUnitType, function(_orgUnit) {
+                    return _orgUnit.id === orgUnit.ParentId;
+                });
+
                 if (parent) {
                     orgUnit.Parent = parent;
                 }
@@ -73,9 +79,46 @@ define(['exports'], function(exports) {
     /**
      * Return the tripos structure
      *
+     * @param  {Number}      [appId]              The application to retrieve the tripos structure for
      * @param  {Function}    callback             Standard callback function
      * @param  {Object}      callback.err         Error object containing the error code and error message
      * @param  {Object}      callback.response    The tripos structure
+     *
+     * * The returned tripos structure will be something in the lines of:
+     * *
+     * * {
+     * *     'courses': [
+     * *         {orgUnit}
+     * *     ],
+     * *     'subjects': [
+     * *         {orgUnit}
+     * *     ],
+     * *     'parts': [
+     * *         {
+     * *             'id': {Number},
+     * *             'displayName': {String},
+     * *             'ParentId': {Number},
+     * *             'Parent': {
+     * *                 'id': {Number},
+     * *                 'displayName': {String},
+     * *                 'ParentId': {Number},
+     * *                 'Parent': {
+     * *                     'id': {Number},
+     * *                     'displayName': {String},
+     * *                     'ParentId': {null},
+     * *                     ...
+     * *                 },
+     * *             },
+     * *             ...
+     * *         },
+     * *         {
+     * *             'id':          {Number},
+     * *             'displayName': {String},
+     * *             'ParentId':    {null}
+     * *             ...
+     * *         }
+     * *     ]
+     * * }
      */
     var getTriposStructure = exports.getTriposStructure = function(appId, callback) {
         if (!_.isFunction(callback)) {
@@ -85,11 +128,10 @@ define(['exports'], function(exports) {
         }
 
         var core = require('gh.core');
-        /* istanbul ignore next */
         if (!appId) {
             appId = core.data.me && core.data.me.AppId ? core.data.me.AppId : null;
         }
-        /* istanbul ignore next */
+
         require('gh.api.orgunit').getOrgUnits(appId, false, true, null, ['course', 'subject', 'part'], function(err, data) {
             if (err) {
                 return callback(err);

--- a/shared/gh/js/utils/gh.utils.templates.js
+++ b/shared/gh/js/utils/gh.utils.templates.js
@@ -76,6 +76,7 @@ define(['exports', 'gh.constants'], function(exports, constants) {
             'text!gh/partials/new-series.html',
             'text!gh/partials/rename-module-modal.html',
             'text!gh/partials/series-borrowed-popover.html',
+            'text!gh/partials/series-borrowed-published-popover.html',
             'text!gh/partials/series-info.html',
             'text!gh/partials/series-info-popover.html',
             'text!gh/partials/student-module-item.html',

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -452,7 +452,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
     var setUpPreviewCalendar = function(callback) {
         // Fetch the triposes
         if (!triposData) {
-            gh.utils.getTriposStructure(function(err, data) {
+            gh.utils.getTriposStructure(null, function(err, data) {
                 if (err) {
                     return gh.utils.notification('Could not fetch triposes', constants.messaging.default.error, 'error');
                 }

--- a/shared/gh/js/views/gh.admin-listview.js
+++ b/shared/gh/js/views/gh.admin-listview.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'gh.new-module', 'gh.borrow-series', 'gh.new-series', 'gh.rename-module', 'gh.delete-module', 'clickover'], function(gh) {
+define(['gh.core', 'gh.borrow-series', 'gh.delete-module', 'gh.new-module', 'gh.new-series', 'gh.rename-module', 'gh.series-borrowed-popover', 'clickover'], function(gh) {
 
     /**
      * Set up the modules of events in the sidebar. Note that the generic gh.listview.js does

--- a/shared/gh/js/views/gh.borrow-series.js
+++ b/shared/gh/js/views/gh.borrow-series.js
@@ -102,7 +102,7 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit'], function(gh, constants, or
         var partId = $(this).closest('#gh-modules-list-container').data('partid');
 
         // Fetch the triposes
-        gh.utils.getTriposStructure(function(err, _triposData) {
+        gh.utils.getTriposStructure(null, function(err, _triposData) {
             // Cache the triposdata for use in the other picker
             triposData = _triposData;
 

--- a/shared/gh/js/views/gh.listview.js
+++ b/shared/gh/js/views/gh.listview.js
@@ -37,6 +37,11 @@ define(['gh.utils', 'gh.api.orgunit', 'gh.constants'], function(utils, orgunitAP
         // Sort the data before displaying it
         modules.results.sort(utils.sortByDisplayName);
         $.each(modules.results, function(i, module) {
+
+            // Decorate the series with their parent info
+            utils.decorateBorrowedSeriesWithParentInfo(module.Series);
+
+            // Sort the series by their display name
             module.Series.sort(utils.sortByDisplayName);
         });
 

--- a/shared/gh/js/views/gh.listview.js
+++ b/shared/gh/js/views/gh.listview.js
@@ -169,45 +169,6 @@ define(['gh.utils', 'gh.api.orgunit', 'gh.constants'], function(utils, orgunitAP
     };
 
 
-    ///////////////
-    //  POPOVER  //
-    ///////////////
-
-    /**
-     * Set up and show the series popover
-     *
-     * @private
-     */
-    var setUpSeriesPopover = function() {
-        var $trigger = $(this);
-        var $content = $('.list-group-item .popover.borrowing[data-id="' + $trigger.data('id') + '"]');
-
-        var options = {
-            'class_name': 'gh-series-popover gh-borrowed-popover',
-            'container': 'body',
-            'content': $content.html(),
-            'global_close': true,
-            'html': true
-        };
-
-        $trigger.clickover(options);
-        $trigger.trigger('click');
-    };
-
-    /**
-     * Dismiss the popover window
-     *
-     * @private
-     */
-    var dismissSeriesPopover = function() {
-        var $trigger = $(this);
-        // Only invoke a click when a popover is actually being shown
-        if ($('.popover.in').length) {
-            $trigger.trigger('click');
-        }
-    };
-
-
     /////////////
     // BINDING //
     /////////////
@@ -220,11 +181,6 @@ define(['gh.utils', 'gh.api.orgunit', 'gh.constants'], function(utils, orgunitAP
     var addBinding = function() {
         // Toggle a list item
         $('body').on('click', '.gh-toggle-list', toggleList);
-
-        // Hide the popover window
-        $('body').on('mouseout', '.list-group-item .fa-link', dismissSeriesPopover);
-        // Show extra information for the borrowed series
-        $('body').on('mouseover', '.list-group-item .fa-link', setUpSeriesPopover);
 
         // Set up the modules list
         $(document).on('gh.part.selected', setUpModules);

--- a/shared/gh/js/views/gh.series-borrowed-popover.js
+++ b/shared/gh/js/views/gh.series-borrowed-popover.js
@@ -65,7 +65,6 @@ define(['gh.utils', 'clickover'], function(utils) {
      * @private
      */
     var addBinding = function() {
-
         // Hide the popover window
         $('body').on('mouseout', '.list-group-item .fa-link', dismissSeriesPopover);
         // Show extra information for the borrowed series

--- a/shared/gh/js/views/gh.series-borrowed-popover.js
+++ b/shared/gh/js/views/gh.series-borrowed-popover.js
@@ -1,0 +1,76 @@
+/*!
+ * Copyright 2015 Digital Services, University of Cambridge Licensed
+ * under the Educational Community License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['gh.utils', 'clickover'], function(utils) {
+
+
+    ///////////////
+    //  POPOVER  //
+    ///////////////
+
+    /**
+     * Set up and show the series popover
+     *
+     * @private
+     */
+    var setUpSeriesPopover = function() {
+        var $trigger = $(this);
+        var $content = $('.list-group-item .popover.borrowing[data-id="' + $trigger.data('id') + '"]');
+
+        var options = {
+            'class_name': 'gh-series-popover gh-borrowed-popover',
+            'container': 'body',
+            'content': $content.html(),
+            'global_close': true,
+            'html': true
+        };
+
+        $trigger.clickover(options);
+        $trigger.trigger('click');
+    };
+
+    /**
+     * Dismiss the popover window
+     *
+     * @private
+     */
+    var dismissSeriesPopover = function() {
+        var $trigger = $(this);
+        // Only invoke a click when a popover is actually being shown
+        if ($('.popover.in').length) {
+            $trigger.trigger('click');
+        }
+    };
+
+
+    /////////////
+    // BINDING //
+    /////////////
+
+    /**
+     * Add handlers to the popover triggers
+     *
+     * @private
+     */
+    var addBinding = function() {
+
+        // Hide the popover window
+        $('body').on('mouseout', '.list-group-item .fa-link', dismissSeriesPopover);
+        // Show extra information for the borrowed series
+        $('body').on('mouseover', '.list-group-item .fa-link', setUpSeriesPopover);
+    };
+
+    addBinding();
+});

--- a/shared/gh/js/views/gh.series-borrowed-published-popover.js
+++ b/shared/gh/js/views/gh.series-borrowed-published-popover.js
@@ -1,0 +1,75 @@
+/*!
+ * Copyright 2015 Digital Services, University of Cambridge Licensed
+ * under the Educational Community License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['gh.utils', 'clickover'], function(utils) {
+
+
+    ///////////////
+    //  POPOVER  //
+    ///////////////
+
+    /**
+     * Set up and show the popover window
+     *
+     * @private
+     */
+    var setUpPopover = function() {
+        var $trigger = $(this);
+        var $content = $('.list-group-item .popover.published[data-id="' + $trigger.data('id') + '"]');
+
+        var options = {
+            'class_name': 'gh-series-popover gh-borrowed-published-popover',
+            'container': 'body',
+            'content': $content.html(),
+            'global_close': true,
+            'html': true
+        };
+
+        $trigger.clickover(options);
+        $trigger.trigger('click');
+    };
+
+    /**
+     * Dismiss the popover window
+     *
+     * @private
+     */
+    var dismissPopover = function() {
+        var $trigger = $(this);
+        // Only invoke a click when a popover is actually being shown
+        if ($('.popover.in').length) {
+            $trigger.trigger('click');
+        }
+    };
+
+
+    /////////////
+    // BINDING //
+    /////////////
+
+    /**
+     * Add handlers to the popover triggers
+     *
+     * @private
+     */
+    var addBinding = function() {
+        // Hide the popover window
+        $('body').on('mouseout', '.gh-list-action .gh-disabled-overlay', dismissPopover);
+        // set up and show the popover window
+        $('body').on('mouseover', '.gh-list-action .gh-disabled-overlay', setUpPopover);
+    };
+
+    addBinding();
+});

--- a/shared/gh/js/views/gh.student-listview.js
+++ b/shared/gh/js/views/gh.student-listview.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'gh.constants', 'gh.series-info', 'clickover'], function(gh, constants) {
+define(['gh.core', 'gh.constants', 'gh.series-info', 'gh.series-borrowed-popover', 'gh.series-borrowed-published-popover', 'clickover'], function(gh, constants) {
 
     var modules = null;
 

--- a/shared/gh/partials/series-borrowed-popover.html
+++ b/shared/gh/partials/series-borrowed-popover.html
@@ -1,3 +1,20 @@
 <div class="popover fade gh-series-popover borrowing" role="tooltip" data-id="<%- data.id %>">
-    <strong>Belongs to:</strong></br><%- data.borrowedFrom.displayName %>
+
+    <!-- Module -->
+    This series belongs to <strong><%- data.borrowedFrom.displayName %></strong>
+
+    <!-- Part -->
+    <% if (data.borrowedFrom.Parent) { %>
+        in <strong><%- data.borrowedFrom.Parent.displayName %></strong>
+
+        <!-- Tripos -->
+        <% if (data.borrowedFrom.Parent.Parent) { %>
+            in <strong><%- data.borrowedFrom.Parent.Parent.displayName %></strong>
+
+            <!-- Course -->
+            <% if (data.borrowedFrom.Parent.Parent.Parent) { %>
+                in <strong><%- data.borrowedFrom.Parent.Parent.Parent.displayName %></strong>
+            <% } %>
+        <% } %>
+    <% } %>
 </div>

--- a/shared/gh/partials/series-borrowed-published-popover.html
+++ b/shared/gh/partials/series-borrowed-published-popover.html
@@ -1,3 +1,19 @@
 <div class="popover fade gh-series-popover published" role="tooltip" data-id="<%- data.id %>">
-    This series belongs to <strong><%- data.borrowedFrom.displayName%></strong> in <strong>{{tripos}}</strong> / <strong>{{part}}</strong> which is not published yet.
+
+    <!-- Part -->
+    <% if (data.borrowedFrom.Parent) { %>
+        This series belongs to <strong><%- data.borrowedFrom.Parent.displayName %></strong>
+
+        <!-- Tripos -->
+        <% if (data.borrowedFrom.Parent.Parent) { %>
+            in <strong><%- data.borrowedFrom.Parent.Parent.displayName %></strong>
+
+            <!-- Course -->
+            <% if (data.borrowedFrom.Parent.Parent.Parent) { %>
+                in <strong><%- data.borrowedFrom.Parent.Parent.Parent.displayName %></strong>
+            <% } %>
+        <% } %>
+
+        which is not published yet.
+    <% } %>
 </div>

--- a/shared/gh/partials/series-borrowed-published-popover.html
+++ b/shared/gh/partials/series-borrowed-published-popover.html
@@ -1,0 +1,3 @@
+<div class="popover fade gh-series-popover published" role="tooltip" data-id="<%- data.id %>">
+    This series belongs to <strong><%- data.borrowedFrom.displayName%></strong> in <strong>{{tripos}}</strong> / <strong>{{part}}</strong> which is not published yet.
+</div>

--- a/shared/gh/partials/student-module-item.html
+++ b/shared/gh/partials/student-module-item.html
@@ -60,6 +60,9 @@
                 <!-- Borrowed popover-->
                 <%= _.partial('series-borrowed-popover', {'data': d}) %>
 
+                <!-- Borrowed popover-->
+                <%= _.partial('series-borrowed-published-popover', {'data': d}) %>
+
                 <!-- Borrowed icon -->
                 <div class="gh-series-borrowed">
                     <% if (d.borrowedFrom) { %>
@@ -72,6 +75,12 @@
 
             <!-- Series actions -->
             <div class="gh-list-action">
+
+                <!-- Disabled button overlay -->
+                <% if (d.borrowedFrom && d.borrowedFrom.published) { %>
+                    <div class="gh-disabled-overlay" data-id="<%- d.id %>"></div>
+                <% } %>
+
                 <% if (d.subscribed || (!isChild && subscribedAll)) { %>
                     <button class="btn btn-link <% if (isChild) { %>gh-remove-from-calendar<% } else { %>gh-remove-all-from-calendar<% } %>" <% if (d.borrowedFrom && d.borrowedFrom.published) { %>disabled<% } %>>
                         <i class="fa fa-remove"></i>

--- a/shared/gh/partials/student-module-item.html
+++ b/shared/gh/partials/student-module-item.html
@@ -73,15 +73,15 @@
             <!-- Series actions -->
             <div class="gh-list-action">
                 <% if (d.subscribed || (!isChild && subscribedAll)) { %>
-                    <button class="btn btn-link <% if (isChild) { %> gh-remove-from-calendar <% } else { %> gh-remove-all-from-calendar <% } %>">
+                    <button class="btn btn-link <% if (isChild) { %>gh-remove-from-calendar<% } else { %>gh-remove-all-from-calendar<% } %>" <% if (d.borrowedFrom && d.borrowedFrom.published) { %>disabled<% } %>>
                         <i class="fa fa-remove"></i>
                     </button>
                 <% } else { %>
-                    <button class="btn btn-link <% if (isChild) { %> gh-add-to-calendar <% } else { %> gh-add-all-to-calendar <% } %>">
+                    <button class="btn btn-link <% if (isChild) { %>gh-add-to-calendar<% } else { %>gh-add-all-to-calendar<% } %>" <% if (d.borrowedFrom && d.borrowedFrom.published) { %>disabled<% } %>>
                         <% if (!isChild && subscribedSome) { %>
-                        <i class="fa fa-minus"></i>
+                            <i class="fa fa-minus"></i>
                         <% } else { %>
-                        <i class="fa fa-plus"></i>
+                            <i class="fa fa-plus"></i>
                         <% } %>
                     </button>
                 <% } %>

--- a/shared/gh/partials/student-module-item.html
+++ b/shared/gh/partials/student-module-item.html
@@ -77,16 +77,16 @@
             <div class="gh-list-action">
 
                 <!-- Disabled button overlay -->
-                <% if (d.borrowedFrom && d.borrowedFrom.published) { %>
+                <% if (d.borrowedFrom && d.borrowedFrom.Parent && !d.borrowedFrom.Parent.published) { %>
                     <div class="gh-disabled-overlay" data-id="<%- d.id %>"></div>
                 <% } %>
 
                 <% if (d.subscribed || (!isChild && subscribedAll)) { %>
-                    <button class="btn btn-link <% if (isChild) { %>gh-remove-from-calendar<% } else { %>gh-remove-all-from-calendar<% } %>" <% if (d.borrowedFrom && d.borrowedFrom.published) { %>disabled<% } %>>
+                    <button class="btn btn-link <% if (isChild) { %>gh-remove-from-calendar<% } else { %>gh-remove-all-from-calendar<% } %>" <% if (d.borrowedFrom && d.borrowedFrom.Parent && !d.borrowedFrom.Parent.published) { %>disabled<% } %>>
                         <i class="fa fa-remove"></i>
                     </button>
                 <% } else { %>
-                    <button class="btn btn-link <% if (isChild) { %>gh-add-to-calendar<% } else { %>gh-add-all-to-calendar<% } %>" <% if (d.borrowedFrom && d.borrowedFrom.published) { %>disabled<% } %>>
+                    <button class="btn btn-link <% if (isChild) { %>gh-add-to-calendar<% } else { %>gh-add-all-to-calendar<% } %>" <% if (d.borrowedFrom && d.borrowedFrom.Parent && !d.borrowedFrom.Parent.published) { %>disabled<% } %>>
                         <% if (!isChild && subscribedSome) { %>
                             <i class="fa fa-minus"></i>
                         <% } else { %>

--- a/shared/gh/partials/subheader-part.html
+++ b/shared/gh/partials/subheader-part.html
@@ -3,6 +3,6 @@
     <% if (data.excludePart !== part.id) { %>
         <option value="<%- part.id %>"><%- part.displayName %><% if(!part.published) { %> - Draft<% } %></option>
     <% } else { %>
-        <option value="" disabled><%- part.displayName %><% if(!part.published) { %> - Draft<% } %></option>
+        <option value="" disabled><%- part.displayName %><% if(!part.published) { %> - Draft (N/A)<% } %></option>
     <% } %>
 <% }); %>

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -1012,8 +1012,9 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
         });
     });
 
+    // Test the 'getTriposStructure' functionality
     QUnit.asyncTest('getTriposStructure', function(assert) {
-        expect(3);
+        expect(8);
 
         // Verify that an error is thrown when an invalid value for app id was provided
         assert.throws(function() {
@@ -1030,7 +1031,30 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
             gh.utils.getTriposStructure(null, 'invalid_callback');
         }, 'Verify that an error is thrown when an invalid callback was provided');
 
-        QUnit.start();
+        // Retrieve the tripos structure for the test application
+        var testApp = testAPI.getTestApp();
+        gh.utils.getTriposStructure(testApp.id, function(err, data) {
+            assert.ok(!err, 'Verify that the tripos structure can be requested without errors');
+            assert.ok(data, 'Verify that the tripos structure is returned');
+
+            // Retrieve the tripos structure when the application ID was set in the `me` object
+            gh.data.me.AppId = testApp.id;
+            gh.utils.getTriposStructure(null, function(err, data) {
+                assert.ok(!err, 'Verify that the tripos structure can be requested without errors');
+                assert.ok(data, 'Verify that the tripos structure is returned');
+
+                // Remove the application ID from the `me` object
+                if (gh.data.me.AppId) {
+                    delete gh.data.me.AppId;
+                }
+
+                // Retrieve the tripos structure when no application ID was set
+                gh.utils.getTriposStructure(null, function(err, data) {
+                    assert.ok(err, 'Verify that an error is thrown when no application ID is set');
+                    QUnit.start();
+                });
+            });
+        });
     });
 
 

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -877,6 +877,7 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
         assert.equal(returnedHTML, 'Hi, Mathieu', 'Verify the rendered HTML returns when no target container is specified');
     });
 
+    // Test the 'RenderTemplate - Partials' functionality
     QUnit.test('renderTemplate - Partials', function(assert) {
         // Verify that a partial can be used to render a template
         // Add a template to the page
@@ -898,6 +899,16 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
     ////////////////
     //  TRIPOSES  //
     ////////////////
+
+    // Test the 'decorateBorrowedSeriesWithParentInfo' functionality
+    QUnit.asyncTest('decorateBorrowedSeriesWithParentInfo', function(assert) {
+        expect(1);
+    });
+
+    // Test the 'addParentInfoToOrgUnit' functionality
+    QUnit.asyncTest('addParentInfoToOrgUnit', function(assert) {
+        expect(1);
+    });
 
     QUnit.asyncTest('getTriposStructure', function(assert) {
         expect(2);


### PR DESCRIPTION
This is a placeholder / braindump ticket to handle a couple of (edge) cases around borrowing:

**Borrowing from the same module in which you would like to borrow**
In borrowing modal, the current module should be visible, but disabled

**Publishing a part which has series in it which belong to a part which hasn't been published yet**
Admins should be able to borrow series from parts which are not published yet, with the principle that unpublished series from other departments shouldn't hold up timetable creation.

On the student UI, we could do this to deal with this case:

Unpublished series should be displayed, but the Add button disabled. If somebody clicks on Add event button, a tooltip could be displayed with the following copy:

This {{event_type}} is belongs to {{tripos}} / {{part}} which is not published yet.
You will be able to add this to your calendar once it is published.




 