### PR TITLE
Adjust date & time column width to fit all dates @ 1280px wide screen

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -478,7 +478,7 @@
 
 #gh-batch-edit-header .table thead tr th:nth-child(3),
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr > th:nth-child(3) {
-    width: 180px;
+    width: 220px;
 }
 
 #gh-batch-edit-header .table thead tr th:nth-child(4),
@@ -885,17 +885,10 @@
     text-overflow: ellipsis;
 }
 
-.gh-event-date {
-    max-width: 250px !important;
-    min-width: 210px !important;
-}
-
 .gh-event-display-date {
     line-height: 20px;
     margin-left: 30px;
     margin-top: -10px;
-    max-width: 170px;
-    text-overflow: ellipsis;
 }
 
 .gh-event-delete,


### PR DESCRIPTION
3dotting should never happen for dates & times in the event listing page, at 1280px wide screens.

We should adjust the width of the date column (at the expense of the event title column) to make sure that it can take long date formats like W10 Wed 11am - 12pm without 3dotting them.

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6926371/ba7deffa-d7dd-11e4-8497-ae575a5a983b.png)
