### PR TITLE
Add rename and delete module functionality

### DIFF
--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -140,7 +140,7 @@
             <%= _.partial('new-module-modal', {'data': data}) %>
         </script>
 
-        <!-- Rename module -->
+        <!-- Rename module modal -->
         <div id="gh-rename-module-modal-container"><!-- --></div>
         <script id="gh-rename-module-modal-template" type="text/template">
             <%= _.partial('rename-module-modal', {'data': data}) %>
@@ -149,6 +149,12 @@
         <!-- Batch edit template -->
         <script id="gh-batch-edit-template" type="text/template">
             <%= _.partial('admin-batch-edit', {'data': data}) %>
+        </script>
+
+        <!-- Delete module modal -->
+        <div id="gh-delete-module-modal-container"><!-- --></div>
+        <script id="gh-delete-module-modal-template" type="text/template">
+            <%= _.partial('delete-module-modal', {'data': data}) %>
         </script>
 
         <!-- Delete series modal -->

--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -140,6 +140,12 @@
             <%= _.partial('new-module-modal', {'data': data}) %>
         </script>
 
+        <!-- Rename module -->
+        <div id="gh-rename-module-modal-container"><!-- --></div>
+        <script id="gh-rename-module-modal-template" type="text/template">
+            <%= _.partial('rename-module-modal', {'data': data}) %>
+        </script>
+
         <!-- Batch edit template -->
         <script id="gh-batch-edit-template" type="text/template">
             <%= _.partial('admin-batch-edit', {'data': data}) %>

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -333,7 +333,8 @@
 }
 
 #gh-new-module-form .form-group input,
-#gh-new-series-form .form-group input {
+#gh-new-series-form .form-group input,
+#gh-rename-module-form .form-group input {
     font-size: 28px;
     font-weight: 400;
     height: 41px;
@@ -343,6 +344,16 @@
 }
 
 #gh-new-module-form .form-group input {
+    margin: 0;
+    width: 100%;
+}
+
+
+/******************/
+/* RENAME MODULES */
+/******************/
+
+#gh-rename-module-form .form-group input {
     margin: 0;
     width: 100%;
 }

--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -367,11 +367,30 @@
     font-weight: 600;
 }
 
-#gh-delete-series-modal #gh-delete-series-borrowed-list-description {
+#gh-delete-series-modal small {
+    font-size: 15px;
+}
+
+
+/*****************/
+/* DELETE MODULE */
+/*****************/
+
+#gh-delete-module-modal #delete-module-body-preload-container {
+    font-size: 20px;
+    font-weight: 400;
+}
+
+
+/*****************/
+/* BORROWED LIST */
+/*****************/
+
+.gh-borrowed-list-description {
     margin: 20px 0 5px;
 }
 
-#gh-delete-series-modal ul#gh-delete-series-borrowed-list {
+ul.gh-borrowed-list {
     border-bottom-style: solid;
     border-bottom-width: 1px;
     border-top-style: solid;
@@ -382,23 +401,19 @@
     padding: 0;
 }
 
-#gh-delete-series-modal ul#gh-delete-series-borrowed-list li {
+ul.gh-borrowed-list li {
     border-bottom-style: solid;
     border-bottom-width: 1px;
     list-style: none;
     padding: 12px;
 }
 
-#gh-delete-series-modal ul#gh-delete-series-borrowed-list li:last-child {
+ul.gh-borrowed-list li:last-child {
     border-bottom: none;
 }
 
-#gh-delete-series-modal ul#gh-delete-series-borrowed-list li p {
+ul.gh-borrowed-list li p {
     margin: 0;
-}
-
-#gh-delete-series-modal small {
-    font-size: 15px;
 }
 
 

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -221,21 +221,29 @@
 }
 
 
+/************************/
+/* DELETE SERIES/MODULE */
+/************************/
+
+#gh-delete-series-modal small {
+    color: #6C6C6C;
+}
+
+
 /*****************/
-/* DELETE SERIES */
+/* BORROWED LIST */
 /*****************/
 
-#gh-delete-series-modal ul#gh-delete-series-borrowed-list {
+ul.gh-borrowed-list {
     border-bottom-color: #CCC;
     border-top-color: #CCC;
 }
 
-#gh-delete-series-modal ul#gh-delete-series-borrowed-list li {
+ul.gh-borrowed-list li {
     border-bottom-color: #CCC;
 }
 
-#gh-delete-series-modal small,
-#gh-delete-series-modal ul#gh-delete-series-borrowed-list li p:first-child {
+ul.gh-borrowed-list li p:first-child {
     color: #6C6C6C;
 }
 

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -581,6 +581,17 @@ tbody tr:last-child > td.fc-widget-content {
     text-decoration: none;
 }
 
+.list-group .list-group-item .gh-list-group-item-container .gh-toggle-list + ul {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 9px;
+}
+
+.list-group .list-group-item.gh-list-group-item-open .gh-list-group-item-container .gh-toggle-list + ul {
+    display: block;
+}
+
 .list-group-item:first-child,
 .list-group-item:last-child {
     border-radius: 0;

--- a/shared/gh/js/gh.bootstrap.js
+++ b/shared/gh/js/gh.bootstrap.js
@@ -80,6 +80,7 @@ requirejs.config({
         'gh.borrow-series': 'gh/js/views/gh.borrow-series',
         'gh.calendar': 'gh/js/views/gh.calendar',
         'gh.datepicker': 'gh/js/views/gh.datepicker',
+        'gh.delete-module': 'gh/js/views/gh.delete-module',
         'gh.delete-series': 'gh/js/views/gh.delete-series',
         'gh.listview': 'gh/js/views/gh.listview',
         'gh.new-module': 'gh/js/views/gh.new-module',

--- a/shared/gh/js/gh.bootstrap.js
+++ b/shared/gh/js/gh.bootstrap.js
@@ -84,6 +84,7 @@ requirejs.config({
         'gh.listview': 'gh/js/views/gh.listview',
         'gh.new-module': 'gh/js/views/gh.new-module',
         'gh.new-series': 'gh/js/views/gh.new-series',
+        'gh.rename-module': 'gh/js/views/gh.rename-module',
         'gh.series-info': 'gh/js/views/gh.series-info',
         'gh.student-listview': 'gh/js/views/gh.student-listview',
         'gh.subheader': 'gh/js/views/gh.subheader',

--- a/shared/gh/js/utils/gh.utils.templates.js
+++ b/shared/gh/js/utils/gh.utils.templates.js
@@ -62,6 +62,8 @@ define(['exports', 'gh.constants'], function(exports, constants) {
             'text!gh/partials/admin-modules.html',
             'text!gh/partials/borrow-series-modal.html',
             'text!gh/partials/calendar.html',
+            'text!gh/partials/delete-module-modal.html',
+            'text!gh/partials/delete-module-overview.html',
             'text!gh/partials/delete-series-modal.html',
             'text!gh/partials/editable-parts.html',
             'text!gh/partials/empty-timetable.html',

--- a/shared/gh/js/utils/gh.utils.templates.js
+++ b/shared/gh/js/utils/gh.utils.templates.js
@@ -72,6 +72,7 @@ define(['exports', 'gh.constants'], function(exports, constants) {
             'text!gh/partials/header-template.html',
             'text!gh/partials/new-module-modal.html',
             'text!gh/partials/new-series.html',
+            'text!gh/partials/rename-module-modal.html',
             'text!gh/partials/series-borrowed-popover.html',
             'text!gh/partials/series-info.html',
             'text!gh/partials/series-info-popover.html',

--- a/shared/gh/js/views/gh.admin-listview.js
+++ b/shared/gh/js/views/gh.admin-listview.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'gh.new-module', 'gh.borrow-series', 'gh.new-series', 'clickover'], function(gh) {
+define(['gh.core', 'gh.new-module', 'gh.borrow-series', 'gh.new-series', 'gh.rename-module', 'clickover'], function(gh) {
 
     /**
      * Set up the modules of events in the sidebar. Note that the generic gh.listview.js does

--- a/shared/gh/js/views/gh.admin-listview.js
+++ b/shared/gh/js/views/gh.admin-listview.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'gh.new-module', 'gh.borrow-series', 'gh.new-series', 'gh.rename-module', 'clickover'], function(gh) {
+define(['gh.core', 'gh.new-module', 'gh.borrow-series', 'gh.new-series', 'gh.rename-module', 'gh.delete-module', 'clickover'], function(gh) {
 
     /**
      * Set up the modules of events in the sidebar. Note that the generic gh.listview.js does

--- a/shared/gh/js/views/gh.delete-module.js
+++ b/shared/gh/js/views/gh.delete-module.js
@@ -1,0 +1,350 @@
+/*!
+ * Copyright 2015 Digital Services, University of Cambridge Licensed
+ * under the Educational Community License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.api.series'], function(gh, constants, orgUnitAPI, seriesAPI) {
+
+    // Cache the ID of the module that's being deleted
+    var moduleId = null;
+    // Cache the IDs of the series that where borrowed elsewhere
+    var borrowedElsewhere = [];
+    // Cache the template data as we'll be able to reuse it when processing the delete
+    var templateData = {};
+
+
+    ///////////////
+    // UTILITIES //
+    ///////////////
+
+    /**
+     * Validate that the delete confirmation message has been correctly entered and enable or disable
+     * the submit button appropriately
+     *
+     * @return {Boolean}    Returns `true` if the form can be submitted, returns `false` if the confirmation message hasn't been entered correctly
+     * @private
+     */
+    var validateDeleteConfirmation = function() {
+        // The required confirmation message
+        var required = 'DELETE';
+        // The actual, typed, message
+        var actual = $.trim($('#gh-delete-module-form input').val());
+        // Disable the submit button if the message was correctly entered
+        if (required === actual) {
+            $('#gh-delete-module-delete').removeAttr('disabled');
+            return true;
+        } else {
+            $('#gh-delete-module-delete').attr('disabled', 'disabled');
+            return false;
+        }
+    };
+
+    /**
+     * Render the delete module template, displaying the consequences of deleting the module so
+     * the user can make an informed decision on whether or not to go ahead
+     *
+     * @private
+     */
+    var renderDeleteModule = function() {
+        // Render the module overview
+        gh.utils.renderTemplate($('#delete-module-overview-template'), {
+            'data': templateData
+        }, $('#delete-module-overview-container'));
+
+        // Hide the loading indicator
+        $('#delete-module-body-preload-container').hide();
+
+        // Show the confirmation footer
+        $('#delete-module-confirm-container').show();
+    };
+
+    /**
+     * Delete the module and all series inside of it
+     *
+     * @private
+     */
+    var submitDeleteModal = function() {
+        // Only submit the form when the correct message has been typed
+        if (!validateDeleteConfirmation()) {
+            return false;
+        }
+
+        var seriesToDelete = [];
+        var todo = null;
+        var done = 0;
+
+        /**
+         * Delete a series
+         *
+         * @param  {Number}      series      The series to delete
+         * @param  {Function}    callback    Standard callback function
+         * @private
+         */
+        var deleteSeries = function(series, callback) {
+            // If the series was originally created in the module to be deleted and it's borrowed 
+            // into a different module, delete it from the system to delete it everywhere
+            if (series && series.id && _.contains(_.pluck(templateData.borrowedElsewhere, 'seriesId'), series.id)) {
+                // Remove the series from the module
+                seriesAPI.deleteSeries(series.id, function(err) {
+                    done++;
+                    // When we're done, execute the callback
+                    if (todo === done) {
+                        callback(null);
+                    // Call itself when more series need to be fetched
+                    } else {
+                        deleteSeries(seriesToDelete[done], callback);
+                    }
+                });
+            // If the series isn't borrowed into any other modules and was not originally created
+            // in this module only unlink it from the series
+            } else if (series && series.id && !_.contains(templateData.borrowedElsewhere, series.id)) {
+                // Remove the series from the module
+                orgUnitAPI.deleteOrgUnitSeries(moduleId, series.id, function(err) {
+                    done++;
+                    // When we're done, execute the callback
+                    if (todo === done) {
+                        callback(null);
+                    // Call itself when more series need to be fetched
+                    } else {
+                        deleteSeries(seriesToDelete[done], callback);
+                    }
+                });
+            } else {
+                callback(null);
+            }
+        };
+
+        // Get all series inside of the module
+        orgUnitAPI.getOrgUnit(moduleId, true, function(err, moduleOrgUnit) {
+            // Keep track of how much work we have to do
+            todo = moduleOrgUnit.Series.length;
+            seriesToDelete = moduleOrgUnit.Series;
+
+            // Delete the series
+            deleteSeries(seriesToDelete[0], function() {
+                // Delete the module
+                orgUnitAPI.deleteOrgUnit(moduleId, function(err) {
+                    if (err) {
+                        return gh.utils.notification('Could not delete the module', constants.messaging.default.error, 'error');
+                    }
+
+                    // Hide the modal
+                    $('#gh-delete-module-modal').modal('hide');
+
+                    // Show a success notification after the module and all its series have been deleted
+                    gh.utils.notification('The module has been removed', null, 'success');
+
+                    // Remove the module from the navigation
+                    $('.list-group-item[data-id="' + moduleId + '"]').remove();
+
+                    // Remove the module and series from the state
+                    gh.utils.removeFromState(['series', 'module']);
+                });
+            });
+        });
+
+        // Avoid default form submit behaviour
+        return false;
+    };
+
+
+    ////////////////////
+    // INITIALISATION //
+    ////////////////////
+
+    /**
+     * Render and show the 'delete module' modal dialog
+     *
+     * @private
+     */
+    var setUpDeleteModuleModal = function() {
+        // Cache the module ID
+        moduleId = parseInt($(this).attr('data-id'), 10);
+
+        // Render the modal
+        gh.utils.renderTemplate($('#gh-delete-module-modal-template'), {'data': null}, $('#gh-delete-module-modal-container'));
+
+        // Show the modal
+        $('#gh-delete-module-modal').modal();
+    };
+
+    /**
+     * Create a list of organisational units from which series are borrowed from
+     *
+     * @param  {Object}      orgunit     The organisational unit (module) to delete
+     * @param  {Function}    callback    Standard callback function
+     * @private
+     */
+    var retrieveBorrowedOrgUnits = function(orgunit, callback) {
+        borrowedElsewhere = [];
+        _.each(orgunit.Series, function(series) {
+            _.each(series.OrgUnits, function(orgunit, index) {
+                // If the first orgunit in the list is the current module,
+                // any next modules have borrowed this series and should be added to the list
+                if (index !== 0 && series.OrgUnits[0].id === moduleId) {
+                    orgunit.seriesId = series.id;
+                    borrowedElsewhere.push(orgunit);
+                }
+            });
+        });
+
+        // Make sure each entry is unique
+        borrowedElsewhere = _.uniq(borrowedElsewhere, function(item) {
+            return item.id;
+        });
+
+        var todo = borrowedElsewhere.length;
+        var done = 0;
+
+        /**
+         * Get the parent organisational units for modules which borrow a series from the module to delete
+         *
+         * @param  {Object}      module       The module to get the parent organisational units for
+         * @param  {Function}    _callback    Standard callback function
+         * @private
+         */
+        var getBorrowedParents = function(module, _callback) {
+            // Get the module's parent's info (part)
+            orgUnitAPI.getOrgUnit(module.ParentId, false, function(err, part) {
+                module.part = part;
+
+                // Get the part's parent's info (tripos)
+                orgUnitAPI.getOrgUnit(part.ParentId, false, function(err, tripos) {
+                    module.tripos = tripos;
+
+                    done++;
+                    // When we're done, execute the callback
+                    if (todo === done) {
+                        _callback(null, borrowedElsewhere);
+                    // Call itself when more series need to be fetched
+                    } else {
+                        getBorrowedParents(borrowedElsewhere[done], _callback);
+                    }
+                });
+            });
+        };
+
+        // Only retrieve modules parents if there are modules that borrow a series from the module to delete
+        if (borrowedElsewhere.length) {
+            getBorrowedParents(borrowedElsewhere[0], callback);
+        } else {
+            callback(null, borrowedElsewhere);
+        }
+    };
+
+    /**
+     * Retrieve information on all series inside of the organisational unit to delete
+     *
+     * @param  {Object}      orgunit     The organisational unit (module) to delete
+     * @param  {Function}    callback    Standard callback function
+     * @private
+     */
+    var retrieveSeriesInfo = function(orgunit, callback) {
+        var todo = orgunit.Series.length;
+        var done = 0;
+
+        /**
+         * Retrieve information on a series inside of the organisational unit to delete
+         * 
+         * @param  {Object}      series       The series to retrieve extra information for
+         * @param  {Function}    _callback    Standard callback function
+         * @private
+         */
+        var getSeriesInfo = function(series, _callback) {
+            gh.api.seriesAPI.getSeries(series.id, true, function(seriesErr, series) {
+
+                // Cache the full series profile
+                orgunit.Series[done] = series;
+
+                done++;
+                // When we're done, execute the callback
+                if (todo === done) {
+                    _callback(null, orgunit);
+                // Call itself when more series need to be fetched
+                } else {
+                    getSeriesInfo(orgunit.Series[done], _callback);
+                }
+            });
+        };
+
+        // Only attempt to fetch the module's series if it has any
+        if (orgunit.Series && orgunit.Series.length) {
+            getSeriesInfo(orgunit.Series[0], callback);
+        } else {
+            callback(null, orgunit);
+        }
+    };
+
+    /**
+     * Retrieve all data required to fully inform the user about the decision to delete the module.
+     * This includes data on series that are borrowed into other modules
+     *
+     * @private
+     */
+    var retrieveModuleInfo = function() {
+        // Get the organisational unit info (module)
+        orgUnitAPI.getOrgUnit(moduleId, true, function(err, moduleOrgUnit) {
+            if (err) {
+                gh.utils.notification('Could not fetch module information', constants.messaging.default.error, 'error');
+            }
+
+            // Cache the module on the template data object
+            templateData.moduleOrgUnit = moduleOrgUnit;
+
+            // Get the module's parent's info (part)
+            orgUnitAPI.getOrgUnit(moduleOrgUnit.ParentId, false, function(err, partOrgUnit) {
+                // Cache the module's parent on the template data object
+                templateData.partOrgUnit = partOrgUnit;
+
+                // Get the part's parent's info (tripos)
+                orgUnitAPI.getOrgUnit(partOrgUnit.ParentId, false, function(err, triposOrgUnit) {
+                    // Cache the part's parent on the template data object
+                    templateData.triposOrgUnit = triposOrgUnit;
+
+                    // For each series inside of the module, get the series info and place it on the
+                    // moduleOrgUnit object
+                    retrieveSeriesInfo(moduleOrgUnit, function(err, moduleOrgUnit) {
+
+                        // Compile an object with the orgunits from which the series are borrowed
+                        retrieveBorrowedOrgUnits(moduleOrgUnit, function(err, borrowedElsewhere) {
+                            templateData.borrowedElsewhere = borrowedElsewhere;
+
+                            // Render the delete module overview
+                            renderDeleteModule();
+                        });
+                    });
+                });
+            });
+        });
+    };
+
+
+    /////////////
+    // BINDING //
+    /////////////
+
+    /**
+     * Add handlers to various elements in the delete module modal
+     *
+     * @private
+     */
+    var addBinding = function() {
+        $('body').on('shown.bs.modal', '#gh-delete-module-modal', retrieveModuleInfo);
+        $('body').on('click', '.gh-delete-module', setUpDeleteModuleModal);
+        $('body').on('keyup', '#gh-delete-module-confirm-text', validateDeleteConfirmation);
+        $('body').on('click', '#gh-delete-module-delete', submitDeleteModal);
+        $('body').on('submit', '#gh-delete-module-form', submitDeleteModal);
+    };
+
+    addBinding();
+});

--- a/shared/gh/js/views/gh.delete-module.js
+++ b/shared/gh/js/views/gh.delete-module.js
@@ -71,6 +71,7 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.api.series'], function(
     /**
      * Delete the module and all series inside of it
      *
+     * @return {Boolean}    Returns `false` to avoid default form submit behaviour
      * @private
      */
     var submitDeleteModal = function() {
@@ -216,10 +217,18 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.api.series'], function(
         var getBorrowedParents = function(module, _callback) {
             // Get the module's parent's info (part)
             orgUnitAPI.getOrgUnit(module.ParentId, false, function(err, part) {
+                if (err) {
+                    return gh.utils.notification('Could not get the part\'s information', constants.messaging.default.error, 'error');
+                }
+
                 module.part = part;
 
                 // Get the part's parent's info (tripos)
                 orgUnitAPI.getOrgUnit(part.ParentId, false, function(err, tripos) {
+                    if (err) {
+                        return gh.utils.notification('Could not get the tripos\' information', constants.messaging.default.error, 'error');
+                    }
+
                     module.tripos = tripos;
 
                     done++;
@@ -295,7 +304,7 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.api.series'], function(
         // Get the organisational unit info (module)
         orgUnitAPI.getOrgUnit(moduleId, true, function(err, moduleOrgUnit) {
             if (err) {
-                gh.utils.notification('Could not fetch module information', constants.messaging.default.error, 'error');
+                return gh.utils.notification('Could not fetch module information', constants.messaging.default.error, 'error');
             }
 
             // Cache the module on the template data object

--- a/shared/gh/js/views/gh.delete-series.js
+++ b/shared/gh/js/views/gh.delete-series.js
@@ -49,7 +49,7 @@ define(['gh.core', 'gh.constants', 'gh.api.series', 'gh.api.orgunit'], function(
             $('#gh-delete-series-modal').modal('hide');
 
             // Remove the series from the navigation
-            $('.list-group-item[data-id="' + seriesId + '"').remove();
+            $('.list-group-item[data-id="' + seriesId + '"]').remove();
 
             // Remove the series from the state
             removeSeriesFromState();

--- a/shared/gh/js/views/gh.rename-module.js
+++ b/shared/gh/js/views/gh.rename-module.js
@@ -1,0 +1,108 @@
+/*!
+ * Copyright 2015 Digital Services, University of Cambridge Licensed
+ * under the Educational Community License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['gh.core', 'gh.constants', 'gh.api.orgunit'], function(gh, constants, orgUnitAPI) {
+
+    // Keep track of when the user started
+    var timeFromStart = null;
+
+    // Cache the ID of the module that's being renamed
+    var moduleId = null;
+    // Cache the old display name of the module that's being renamed
+    var oldDisplayName = null;
+
+    /**
+     * Rename the module using the provided title
+     *
+     * @private
+     */
+    var renameModule = function() {
+        // Calculate how long it takes the user to rename the module
+        timeFromStart = (new Date() - timeFromStart) / 1000;
+        // Get the display name of the renamed module
+        var displayName = $(this).find('#gh-module-title').val();
+
+        orgUnitAPI.updateOrgUnit(moduleId, null, displayName, null, null, null, null, null,function(err, module) {
+            // Show a success or failure notification
+            if (err) {
+                return gh.utils.notification('Could not rename ' + oldDisplayName, constants.messaging.default.error, 'error');
+            }
+            gh.utils.notification(oldDisplayName + ' renamed successfully to ' + displayName, null, 'success');
+
+            // Track the user renaming the module
+            gh.utils.trackEvent(['Manage', 'Rename module', 'Completed'], {
+                'time_from_start': timeFromStart
+            });
+
+            // Hide the module modal
+            $('#gh-rename-module-modal').modal('hide');
+
+            // Update the modules list display name
+            $('.list-group-item[data-id="' + moduleId + '"] .gh-toggle-list .gh-list-description-text').text(displayName);
+            $('.list-group-item[data-id="' + moduleId + '"] .gh-toggle-list + ul .gh-rename-module').data('displayname', displayName);
+        });
+
+        return false;
+    };
+
+    /**
+     * Render and show the 'rename module' modal dialog
+     *
+     * @private
+     */
+    var showRenameModuleModal = function() {
+        // Cache the display name and module ID
+        oldDisplayName = $(this).data('displayname');
+        moduleId = parseInt($(this).attr('data-id'), 10);
+
+        // Render the modal
+        gh.utils.renderTemplate($('#gh-rename-module-modal-template'), {
+            'data': {
+                'displayName': oldDisplayName,
+                'moduleId': moduleId
+            }
+        }, $('#gh-rename-module-modal-container'));
+
+        // Show the modal
+        $('#gh-rename-module-modal').modal();
+    };
+
+
+    /////////////
+    // BINDING //
+    /////////////
+
+    /**
+     * Add handlers to various elements in the rename module modal
+     *
+     * @private
+     */
+    var addBinding = function() {
+        $('body').on('click', '.gh-rename-module', showRenameModuleModal);
+        $('body').on('submit', '#gh-rename-module-form', renameModule);
+        $('body').on('shown.bs.modal', '#gh-rename-module-modal', function() {
+            // Track the user starting renaming of a module
+            gh.utils.trackEvent(['Manage', 'Rename module', 'Started']);
+            // Track how long the user takes to rename the module
+            timeFromStart = new Date();
+        });
+        $('body').on('click', '#gh-rename-module-modal [data-dismiss="modal"]', function() {
+            // Track the user cancelling renaming of a module
+            gh.utils.trackEvent(['Manage', 'Rename module', 'Cancelled']);
+        });
+    };
+
+    addBinding();
+});

--- a/shared/gh/partials/admin-module-item.html
+++ b/shared/gh/partials/admin-module-item.html
@@ -33,6 +33,31 @@
                         </div>
                     <% } %>
                 </button>
+                <% if (!isChild) { %>
+                    <ul class="nav nav-pills pull-right" role="tablist">
+                        <li role="presentation" class="dropdown">
+                            <button id="gh-batch-edit-settings" class="btn btn-default gh-btn-secondary gh-btn-reverse" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="sr-only">Module settings</span>
+                                <i class="fa fa-cog"></i>
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="gh-batch-edit-settings">
+                                <li role="presentation">
+                                    <button type="button" class="btn btn-default gh-btn-secondary gh-new-series" role="menuitem" data-groupid="<%- groupId %>">New series</button>
+                                </li>
+                                <li role="presentation">
+                                    <button type="button" class="btn btn-default gh-btn-secondary gh-borrow-series" role="menuitem">Borrow series</button>
+                                </li>
+                                <li role="presentation">
+                                    <button type="button" class="btn btn-default gh-btn-secondary gh-rename-module" role="menuitem" data-id="<%- d.id %>" data-displayname="<%- d.displayName %>">Rename module</button>
+                                </li>
+                                <li role="presentation">
+                                    <button type="button" class="btn btn-default gh-btn-secondary gh-delete-module" role="menuitem">Delete module</button>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                <% } %>
         </div>
         <% if (d.Series) { %>
             <ul class="list-group hide">

--- a/shared/gh/partials/admin-module-item.html
+++ b/shared/gh/partials/admin-module-item.html
@@ -49,10 +49,10 @@
                                     <button type="button" class="btn btn-default gh-btn-secondary gh-borrow-series" role="menuitem">Borrow series</button>
                                 </li>
                                 <li role="presentation">
-                                    <button type="button" class="btn btn-default gh-btn-secondary gh-rename-module" role="menuitem" data-id="<%- d.id %>" data-displayname="<%- d.displayName %>">Rename module</button>
+                                    <button type="button" class="btn btn-default gh-btn-secondary gh-rename-module" role="menuitem" data-id="<%= d.id %>" data-displayname="<%- d.displayName %>">Rename module</button>
                                 </li>
                                 <li role="presentation">
-                                    <button type="button" class="btn btn-default gh-btn-secondary gh-delete-module" role="menuitem">Delete module</button>
+                                    <button type="button" class="btn btn-default gh-btn-secondary gh-delete-module" role="menuitem" data-id="<%= d.id %>">Delete module</button>
                                 </li>
                             </ul>
                         </li>

--- a/shared/gh/partials/delete-module-modal.html
+++ b/shared/gh/partials/delete-module-modal.html
@@ -1,0 +1,30 @@
+<div class="modal fade" id="gh-delete-module-modal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header gh-warning">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">×</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title" id="modal-title">Are you sure?</h4>
+            </div>
+            <div class="modal-body">
+                <div id="delete-module-body-preload-container" class="text-center">
+                    <p>Gathering data</p>
+                    <i class="fa fa-spinner fa-spin"></i>
+                </div>
+
+                <div id="delete-module-overview-container"><!-- --></div>
+                <script id="delete-module-overview-template" type="text/template">
+                    <%= _.partial('delete-module-overview', {'data': data}, false) %>
+                </script>
+            </div>
+            <div class="modal-footer">
+                <div id="delete-module-confirm-container" style="display: none;">
+                    <button type="button" class="btn btn-link pull-left" data-dismiss="modal">Cancel</button>
+                    <button type="button" id="gh-delete-module-delete" class="btn btn-default pull-right" disabled="disabled">Delete module &amp; all series inside</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/shared/gh/partials/delete-module-overview.html
+++ b/shared/gh/partials/delete-module-overview.html
@@ -1,0 +1,22 @@
+<p>You are deleting the module <%- data.moduleOrgUnit.displayName %> and <strong>ALL series inside it</strong> from <%- data.triposOrgUnit.displayName %>/<%- data.partOrgUnit.displayName %></p>
+<p>Students will not be able to add this module or any of the lecture series to their calendars, and in calendars already added, it will be removed within a few hours</p>
+
+<% if (data.borrowedElsewhere.length) { %>
+    <p class="gh-borrowed-list-description"><%= data.borrowedElsewhere.length %> other module<% if (data.borrowedElsewhere.length !== 1) { %>s<% } %> borrowed a series from this module:</p>
+
+    <ul class="gh-borrowed-list">
+    <% _.each(data.borrowedElsewhere, function(orgunit, index) { %>
+        <li>
+            <p><%- orgunit.tripos.displayName %> / <%- orgunit.part.displayName %></p>
+            <p><%- orgunit.displayName %></p>
+        </li>
+    <% }); %>
+    </ul>
+<% } %>
+
+<form id="gh-delete-module-form" role="form" data-toggle="validator">
+    <div class="form-group">
+        <label for="gh-delete-module-confirm-text"><strong>Please enter the word &quot;DELETE&quot; below to confirm</strong></label>
+        <input type="text" class="form-control" id="gh-delete-module-confirm-text" placeholder="Type DELETE here" required>
+    </div>
+</form>

--- a/shared/gh/partials/delete-series-modal.html
+++ b/shared/gh/partials/delete-series-modal.html
@@ -16,8 +16,8 @@
                 <% } %>
 
                 <% if (data.isBorrowedTo && !data.isBorrowedFrom) { %>
-                    <p id="gh-delete-series-borrowed-list-description">The series has been borrowed in <%= data.series.OrgUnits.length - 1 %> other module<% if (data.series.OrgUnits.length - 1 !== 1) { %>s<% } %>:</p>
-                    <ul id="gh-delete-series-borrowed-list">
+                    <p class="gh-borrowed-list-description">The series has been borrowed in <%= data.series.OrgUnits.length - 1 %> other module<% if (data.series.OrgUnits.length - 1 !== 1) { %>s<% } %>:</p>
+                    <ul class="gh-borrowed-list">
                     <% _.each(data.series.OrgUnits, function(orgunit, index) { %>
                         <% if (index) { %>
                             <li>

--- a/shared/gh/partials/rename-module-modal.html
+++ b/shared/gh/partials/rename-module-modal.html
@@ -1,0 +1,25 @@
+<div class="modal fade" id="gh-rename-module-modal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">
+                    <span aria-hidden="true">×</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title" id="modal-title">Rename module</h4>
+            </div>
+            <form id="gh-rename-module-form" role="form">
+                <div class="modal-body">
+                    <div class="form-group">
+                        <label for="gh-module-title">Title</label>
+                        <input type="text" class="form-control required" id="gh-module-title" placeholder="Enter the title for the module" value="<%- data.displayName %>">
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-link pull-left" data-dismiss="modal">Cancel</button>
+                    <button type="submit" class="btn btn-default pull-right">Save</button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
* [x] Add cog menu next to module title in the left hand nav list.
* [x] The module cog menu should only be displayed when a module is in open state in the list
* [x] "Rename module" should trigger the rename modal dialog as per design below
* [x] "Delete module" should trigger the delete modal dialog as per design below
* [x] In delete module conformation dialog, the primary action of the modal should be disabled by default and should only be enabled when the word "DELETE" is typed in the conformation input box. Validation should happen on each keypress. If validation is fine, on enabled primary action button click the module and all of its series should be deleted.
* [x] "New series" should trigger exactly what is triggered with the existing new series button
* [x] "Borrow series" should trigger exactly what is triggered with the existing borrow button

* [x] As a stretch goal, the delete modal should display the aggregated borrow information as we do on the delete series conformation modal

![module level cog menu](https://cloud.githubusercontent.com/assets/117483/6928227/a4753526-d7ea-11e4-9189-9e954f3415c7.png)

![rename module 2](https://cloud.githubusercontent.com/assets/117483/6928235/ac0f79ae-d7ea-11e4-9d3a-7d36904fb93a.png)

![delete module conformation](https://cloud.githubusercontent.com/assets/117483/6928240/b6bf4a00-d7ea-11e4-9f16-7cac80a991c5.png)





