### PR TITLE
Close modals on hashchange

### DIFF
--- a/shared/gh/js/views/gh.subheader.js
+++ b/shared/gh/js/views/gh.subheader.js
@@ -183,7 +183,9 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.visibility', 'chosen'],
      *
      * @private
      */
-    var handleStateChange = function(a, b, c) {
+    var handleStateChange = function() {
+        // Close all modal dialogs
+        $('.modal').modal('hide');
 
         // Make sure that all state data is set before handling the statechange event
         gh.utils.setStateData();


### PR DESCRIPTION
When the user navigates back and forth in the browser window while a modal is open, the modal won't be hidden because we don't need to refresh the page to navigate between states.

When the hashchange logic is executed it should close all open modals.