### PR TITLE
Add on hover contextual help for batch edit

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -485,6 +485,35 @@ ul.gh-borrowed-list li p {
     text-decoration: none;
 }
 
+#gh-batch-edit-header {
+    position: relative;
+}
+
+#gh-batch-edit-header #gh-batch-edit-header-disabled-overlay {
+    height: 100%;
+    opacity: 0;
+    position: absolute;
+    -webkit-transition: opacity .3s;
+       -moz-transition: opacity .3s;
+            transition: opacity .3s;
+    width: 100%;
+    z-index: -1;
+}
+
+#gh-batch-edit-header.gh-disabled:hover #gh-batch-edit-header-disabled-overlay {
+    opacity: 1;
+    z-index: 1;
+}
+
+#gh-batch-edit-header #gh-batch-edit-header-disabled-overlay p {
+    font-weight: 400;
+    margin: 14px 0;
+}
+
+#gh-batch-edit-header #gh-batch-edit-header-disabled-overlay p strong {
+    font-weight: 600;
+}
+
 #gh-batch-edit-header button,
 #gh-batch-edit-header input[type="text"]:not(.as-input),
 #gh-batch-edit-header select,

--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -263,6 +263,14 @@ ul.gh-borrowed-list li p:first-child {
     color: #171717;
 }
 
+#gh-batch-edit-header #gh-batch-edit-header-disabled-overlay {
+    background-color: #DDD;
+}
+
+#gh-batch-edit-header #gh-batch-edit-header-disabled-overlay p i {
+    color: #62326E;
+}
+
 #gh-batch-edit-header button:not(:disabled),
 #gh-batch-edit-header input:not(:disabled)[type="text"],
 #gh-batch-edit-header select:not(:disabled),

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -326,6 +326,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
             $('.gh-batch-edit-events-container:not(.gh-ot) thead .gh-select-all:checked').length) {
             $('input, button, select', $('#gh-batch-edit-header')).removeAttr('disabled');
             $('.as-selections', $('#gh-batch-edit-header')).removeClass('gh-disabled');
+            $('#gh-batch-edit-header').removeClass('gh-disabled');
         } else {
             if ($('#gh-batch-edit-header').hasClass('gh-batch-edit-time-open')) {
                 gh.utils.trackEvent(['Data', 'Batch edit', 'TimeDate', 'Closed']);
@@ -333,6 +334,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
             $('#gh-batch-edit-header').removeClass('gh-batch-edit-time-open');
             $('input, button, select', $('#gh-batch-edit-header')).attr('disabled', 'disabled');
             $('.as-selections', $('#gh-batch-edit-header')).addClass('gh-disabled');
+            $('#gh-batch-edit-header').addClass('gh-disabled');
         }
     };
 

--- a/shared/gh/partials/admin-batch-edit.html
+++ b/shared/gh/partials/admin-batch-edit.html
@@ -50,7 +50,12 @@
                 <% } %>
 
                 <% if (!data.records.borrowedFrom) { %>
-                    <div id="gh-batch-edit-header">
+                    <div id="gh-batch-edit-header" class="gh-disabled">
+                        <div id="gh-batch-edit-header-disabled-overlay">
+                            <p class="text-center">
+                                <i class="fa fa-info-circle"></i> <strong>Batch edit:</strong> Select one or more events first to batch edit them here all at once!
+                            </p>
+                        </div>
                         <table class="table">
                             <thead>
                                 <tr>


### PR DESCRIPTION
With the following solution we can reinforce that batch edit is available when items are selected, and the fact that it is there in disabled mode:

On hover put an overlay across the whole disabled batch edit components and display a little contextual help message. The message should be hidden when mouse leaves disabled batch edit container.

![batch_edit_hover](https://cloud.githubusercontent.com/assets/117483/6927313/674d5cf6-d7e4-11e4-8afe-149d7aa30876.png)
