### PR TITLE
After Saving a series edit reset the batch editor

### DIFF
--- a/shared/gh/js/views/gh.admin-batch-edit-organiser.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-organiser.js
@@ -44,6 +44,18 @@ define(['gh.core', 'jquery-autosuggest'], function(gh) {
     };
 
     /**
+     * Reset the AutoSuggest component by deleting all of its selected users
+     *
+     * @private
+     */
+    var resetAutoSuggest = function() {
+        // For each of the users, click the `remove` button
+        _.each($('.gh-batch-event-organisers .as-selection-item .as-close'), function($close) {
+            $($close).click();
+        });
+    };
+
+    /**
      * Update a given organiser field in the DOM
      *
      * @param  {jQuery}    $field    jQuery selector of the td element that makes up the organiser field
@@ -277,7 +289,10 @@ define(['gh.core', 'jquery-autosuggest'], function(gh) {
      * @private
      */
     var addBinding = function() {
+        // Set up the AutoSuggest
         $(document).on('gh.batchorganiser.setup', setUpAutoSuggest);
+        // Reset the AutoSuggest
+        $(document).on('gh.batchorganiser.reset', resetAutoSuggest);
         // Close the AutoSuggest when the body is clicked
         $(document).on('click', 'body', closeAutoSuggest);
         // Close the AutoSuggest when the component loses focus

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -349,7 +349,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
         // Reset the location
         $('#gh-batch-edit-location').val('');
         // Reset the type
-        $('#gh-batch-edit-type').val('Lecture');
+        $('#gh-batch-edit-type').val(gh.config.events.default);
         // Reset the organisers
         $(document).trigger('gh.batchorganiser.reset');
     };

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -337,6 +337,22 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
     };
 
     /**
+     * Reset all batch header fields
+     *
+     * @private
+     */
+    var resetBatchHeader = function() {
+        // Reset the title
+        $('#gh-batch-edit-title').val('');
+        // Reset the location
+        $('#gh-batch-edit-location').val('');
+        // Reset the type
+        $('#gh-batch-edit-type').val('Lecture');
+        // Reset the organisers
+        $(document).trigger('gh.batchorganiser.reset');
+    };
+
+    /**
      * Toggles each and every action in the UI to be disabled or enabled based on
      * the parameter passed in to the function
      *
@@ -1098,6 +1114,10 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
                 deleteEvents(eventsToDelete, function(deleteErr) {
                     // Re-enable all elements in the UI
                     disableEnableAll(false);
+                    // Keep the batch edit header disabled as there is no selection after saving
+                    toggleBatchEditEnabled();
+                    // Reset the batch edit header
+                    resetBatchHeader();
 
                     if (updateErr || newErr || deleteErr) {
                         // Show an error notification


### PR DESCRIPTION
Current the batch editor is accessible after an Edit -> Save session, with the input fields not cleared.

When user clicks on Save, all the input fields should be cleared / reset, and the batch editor should go into inactive state

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6896434/3913d646-d6e3-11e4-9828-aee47fd0181a.png)
