### PR TITLE
Add top and bottom border to calendar event display

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -287,6 +287,8 @@
        -moz-border-radius: 0;
             border-radius: 0;
     border: none;
+    border-bottom-style: solid;
+    border-bottom-width: 1px !important;
     border-left-style: solid;
     border-left-width: 5px;
     cursor: pointer;

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -450,6 +450,7 @@ tbody .fc-sun {
 
 .fc-event-container .fc-event {
     background-color: #E7F8F0;
+    border-bottom-color: #198289;
     border-left-color: #198289;
 }
 


### PR DESCRIPTION
In situations like this it is hard to clearly establish events in the calendar:

![my_timetable_apr_23_ _29__2015](https://cloud.githubusercontent.com/assets/117483/6997102/d1af3956-dba5-11e4-9562-d6e8641386e9.png)

Adding a dark/light green hairline to top and bottom borders of the events should help in cases like this. 
