### PR TITLE
Increase size of close icon

### DIFF
--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -266,6 +266,12 @@ select[disabled],
     position: relative;
 }
 
+.modal-header button[data-dismiss="modal"] {
+    font-size: 32px;
+    font-weight: bold;
+    padding: 0 5px;
+}
+
 .modal-body {
     padding: 40px 25px 25px;
 }


### PR DESCRIPTION
This did the trick for me:
  font-weight: bold;
  font-size: 32px;
  padding-right: 10px;

to look like this:
![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6997315/33400980-dbaf-11e4-8976-f1788c570249.png)


