### PR TITLE
Unexpected behaviour when focusing out an editable title field

### DIFF
--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -682,7 +682,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
             'disable': false,
             'height': '38px',
             'maxlength': 255,
-            'onblur': 'submit',
+            'onblur': 'cancel',
             'placeholder': 'Click to add a title for this series',
             'select': true,
             'type': 'series-title',
@@ -697,7 +697,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
         $('.gh-jeditable-events').editable(editableEventSubmitted, {
             'cssclass': 'gh-jeditable-form',
             'height': '38px',
-            'onblur': 'submit',
+            'onblur': 'cancel',
             'placeholder': '',
             'select' : true,
             'callback': function(value, settings) {
@@ -713,6 +713,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
         $('.gh-jeditable-events-select').editable(editableEventTypeSubmitted, {
             'cssclass': 'gh-jeditable-form',
             'disable': false,
+            'onblur': 'cancel',
             'placeholder': '',
             'select': true,
             'tooltip': 'Click to edit the event type',
@@ -729,6 +730,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
         // Apply jEditable to the organisers
         $('.gh-edit-event-organisers').editable(editableOrganiserSubmitted, {
             'cssclass': 'gh-jeditable-form',
+            'onblur': 'cancel',
             'placeholder': '',
             'select': true,
             'tooltip': 'Click to add a lecturer for this event',


### PR DESCRIPTION
When focussing out of an editable series title or event title field, some unexpected behaviour occurs (jeditable form gets submitted).

Steps to reproduce:
1. Click on an editable series title or event title field in the batch edit
2. Click on a series in the left modules/series list