### PR TITLE
Make date input component positioning smarter

### DIFF
--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -1400,8 +1400,12 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
 
         // External edit
         $(document).on('gh.datepicker.change', batchEditDate);
-        $('body').on('click', '.gh-event-date:not(.gh-disabled)', function() {
-            $(document).trigger('gh.datepicker.show', this);
+        $('body').on('click', '.gh-event-date:not(.gh-disabled)', function(ev) {
+            // @see gh.datepicker.js for parameter instructions
+            $(document).trigger('gh.datepicker.show', {
+                'ev': ev,
+                'trigger': this
+            });
         });
 
         // Settings


### PR DESCRIPTION
When we open the date input component, the UI should be mindful about how close it is to the bottom of the window, and position it to the top of the event line if it would crop, eliminating situations where the tooltip would open and you would only see half of it, needing to scroll.

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6997245/aa2409f0-dbac-11e4-909f-6ff916b6f19e.png)

Rough logic could be:
If click point Y coordinate + tooltip height would be off screen > open it to the top of the event line.
If the click point Y coordinate - tooltip height would be off screen > ope it below the event line

Ensuring that it always opens in view, just as the calendar event tooltip knows how to open left and right depending on the position of the event.

