### PR TITLE
Tweak hotspot for selecting borrowed series

### DIFF
--- a/apps/timetable/admin/ui/css/skin.css
+++ b/apps/timetable/admin/ui/css/skin.css
@@ -34,7 +34,8 @@
 }
 
 .btn-default.gh-btn-secondary.gh-btn-reverse:hover,
-.btn-default.gh-btn-secondary.gh-btn-reverse:focus {
+.btn-default.gh-btn-secondary.gh-btn-reverse:focus,
+#gh-borrow-series-modal .list-group .list-group-item .gh-list-description:hover + .gh-list-action button {
     background-color: #62326E;
     border-color: #62326E;
 }

--- a/shared/gh/js/views/gh.borrow-series.js
+++ b/shared/gh/js/views/gh.borrow-series.js
@@ -246,6 +246,10 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit'], function(gh, constants, or
         $('body').on('click', '.gh-borrow-series-select', addSeriesToBorrow);
         // Unmark a series as 'to borrow'
         $('body').on('click', '.gh-borrow-series-deselect', removeSeriesToBorrow);
+        // Mark or unmark a series as 'to borrow' depending on the status
+        $('body').on('click', '.gh-list-description', function() {
+            $(this).next().find('button:visible').click();
+        });
         // Borrow all series marked as 'to borrow' into a module
         $('body').on('click', '#gh-borrow-series-submit', borrowSeries);
     };


### PR DESCRIPTION
When selecting lecture series to be borrowed, we should add the whole title as a hotspot for the Add button. Almost all test participants clicked on the title to add.

![timetable_administration](https://cloud.githubusercontent.com/assets/117483/6919409/9c98027a-d7ae-11e4-87dd-81145ef707ba.png)
 