### PR TITLE
Event popover has an issue with free-text organisers

### DIFF
--- a/shared/gh/partials/event-popover.html
+++ b/shared/gh/partials/event-popover.html
@@ -8,7 +8,7 @@
     <p class="gh-popover-time"><%- moment.utc(data.start).format('dddd h:mma') %> - <%- moment.utc(data.end).format('h:mma') %></p>
     <p class="gh-popover-location"><%- data.location %></p>
     <p class="gh-popover-organiser">
-        <%- _.chain(data.organisers).map(function(organiser) { return organiser.displayName; }).value().join(', ') %>
+        <%- _.chain(data.organisers).map(function(organiser) { return organiser.displayName || organiser; }).value().join(', ') %>
     </p>
     <%
         if (data.context) {


### PR DESCRIPTION
Organisers that were added as free-text aren't displayed properly in the event popover

![screen shot 2015-04-14 at 18 22 34](https://cloud.githubusercontent.com/assets/218391/7142861/65926650-e2d3-11e4-9b5c-8cf1ec97acb1.png)
