### PR TITLE
Student UI: Improve lecture series info

### DIFF
--- a/apps/timetable/ui/index.html
+++ b/apps/timetable/ui/index.html
@@ -112,12 +112,12 @@
             <%= _.partial('empty-timetable', {'data': data}) %>
         </script>
 
-        <!-- Additional series info popover -->
-        <script id="gh-series-info-popover-template" type="text/template">
-            <%= _.partial('series-info-popover', {'data': data}) %>
+        <!-- Additional series info modal template -->
+        <script id="gh-series-info-modal-template" type="text/template">
+            <%= _.partial('series-info-modal', {'data': data}) %>
         </script>
 
-        <!-- Additional series info -->
+        <!-- Additional series info template -->
         <script id="gh-series-info-template" type="text/template">
             <%= _.partial('series-info', {'data': data}) %>
         </script>

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -964,8 +964,7 @@ tbody tr:last-child > td.fc-widget-content {
 .modal #gh-modules-container {
     margin-top: 25px;
     max-height: 400px;
-    overflow-x: hidden;
-    overflow-y: auto;
+    overflow: auto;
 }
 
 /* Series borrowed info popover */
@@ -1198,6 +1197,18 @@ span.gh-agenda-view-middot {
     padding: 25px 25px 0 !important;
 }
 
+#gh-series-info-modal .modal-header i {
+    display: inline-block;
+    margin-left: 8px;
+    margin-right: 8px;
+}
+
+#gh-series-info-modal .modal-header .gh-series-info-hierarchy {
+    max-width: -moz-calc(100% - 50px);
+    max-width: -o-calc(100% - 50px);
+    max-width: -webkit-calc(100% - 50px);
+    max-width: calc(100% - 50px);
+}
 
 #gh-series-info-modal .modal-body {
     padding: 20px;
@@ -1205,8 +1216,9 @@ span.gh-agenda-view-middot {
 
 #gh-series-info-modal .gh-series-info-list {
     margin-top: 15px;
-    max-height: 250px;
-    overflow: scroll;
+    max-height: 325px;
+    overflow-x: hidden;
+    overflow-y: scroll;
 }
 
 /* Term */
@@ -1238,17 +1250,31 @@ span.gh-agenda-view-middot {
 /* Event */
 
 #gh-series-info-modal .gh-series-info-list .gh-series-info-list-event {
+    clear: both;
     height: 35px;
     position: relative;
 }
 
-#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-type,
-#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-date {
-    display: inline-block;
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event > div {
+    float: left;
+}
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-title {
+    max-width: -moz-calc(100% - 230px);
+    max-width: -o-calc(100% - 230px);
+    max-width: -webkit-calc(100% - 230px);
+    max-width: calc(100% - 230px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 #gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-type {
-    min-width: 28px;
+    min-width: 30px;
+}
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-date {
+    min-width: 200px;
 }
 
 #gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-date .gh-event-display-date {

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -984,29 +984,6 @@ tbody tr:last-child > td.fc-widget-content {
     margin-left: 5px;
 }
 
-/* Series info popover */
-
-.gh-student .popover.gh-series-popover.gh-series-info-popover {
-    margin-left: 275px;
-    min-width: 515px;
-}
-
-.gh-student .popover.gh-series-popover.gh-series-info-popover .term-name {
-    display: block;
-    margin-bottom: 5px;
-}
-
-.gh-student .popover.gh-series-popover.gh-series-info-popover .col-sm-4 {
-    margin-bottom: 15px;
-}
-
-.gh-student .popover.gh-series-popover.gh-series-info-popover .gh-popover-location,
-.gh-student .popover.gh-series-popover.gh-series-info-popover .gh-popover-organiser {
-    border-top-style: solid;
-    border-top-width: 1px;
-    padding: 8px 0 5px;
-}
-
 
 /******************************************************/
 /* DROPDOWN                                           */
@@ -1210,4 +1187,79 @@ span.gh-agenda-view-middot {
     line-height: 0;
     margin: 0 3px;
     vertical-align: sub;
+}
+
+
+/*********************/
+/* SERIES INFO MODAL */
+/*********************/
+
+#gh-series-info-modal .modal-header {
+    padding: 25px 25px 0 !important;
+}
+
+
+#gh-series-info-modal .modal-body {
+    padding: 20px;
+}
+
+#gh-series-info-modal .gh-series-info-list {
+    margin-top: 15px;
+    max-height: 250px;
+    overflow: scroll;
+}
+
+/* Term */
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-term {
+    position: relative;
+}
+
+#gh-series-info-modal .gh-series-info-list > div {
+    padding-left: 10px;
+}
+
+#gh-series-info-modal .gh-series-info-list > div:not(:first-child) {
+    padding-top: 20px;
+}
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-no-events {
+    padding: 10px;
+}
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-term strong {
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    display: block;
+    margin-bottom: 15px;
+    padding-bottom: 5px;
+}
+
+/* Event */
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event {
+    height: 35px;
+    position: relative;
+}
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-type,
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-date {
+    display: inline-block;
+}
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-type {
+    min-width: 28px;
+}
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-event .gh-series-info-list-event-date .gh-event-display-date {
+    padding-left: 30px;
+}
+
+/* Metadata */
+
+#gh-series-info-modal .gh-series-info-location,
+#gh-series-info-modal .gh-series-info-organiser {
+    border-top-style: solid;
+    border-top-width: 1px;
+    padding: 10px 15px;
 }

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -964,7 +964,8 @@ tbody tr:last-child > td.fc-widget-content {
 .modal #gh-modules-container {
     margin-top: 25px;
     max-height: 400px;
-    overflow: auto;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 
 /* Series borrowed info popover */
@@ -1217,8 +1218,7 @@ span.gh-agenda-view-middot {
 #gh-series-info-modal .gh-series-info-list {
     margin-top: 15px;
     max-height: 325px;
-    overflow-x: hidden;
-    overflow-y: scroll;
+    overflow: auto;
 }
 
 /* Term */
@@ -1265,6 +1265,7 @@ span.gh-agenda-view-middot {
     max-width: -webkit-calc(100% - 230px);
     max-width: calc(100% - 230px);
     overflow: hidden;
+    padding-right: 7px;
     text-overflow: ellipsis;
     white-space: nowrap;
 }

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -710,3 +710,41 @@ span.gh-agenda-view-middot {
 .agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week .gh-agenda-view-term-event .gh-agenda-view-event-belongs {
     color: #919191;
 }
+
+
+/*********************/
+/* SERIES INFO MODAL */
+/*********************/
+
+/* Header */
+
+#gh-series-info-modal .modal-header {
+    background-color: #07525D;
+}
+
+#gh-series-info-modal .modal-header h4,
+#gh-series-info-modal .modal-header button,
+#gh-series-info-modal .modal-header p {
+    color: #FFF;
+}
+
+/* Term */
+
+#gh-series-info-modal .gh-series-info-list .gh-series-info-list-term strong {
+    border-bottom-color: #DDD;
+}
+
+/* Metadata */
+
+#gh-series-info-modal .gh-series-info-organiser {
+    border-top-color: #AAA;
+}
+
+#gh-series-info-modal .gh-series-info-location {
+    border-top-color: #DDD;
+}
+
+#gh-series-info-modal .gh-series-info-location,
+#gh-series-info-modal .gh-series-info-organiser {
+    background-color: #EEE;
+}

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -736,14 +736,15 @@ span.gh-agenda-view-middot {
 
 /* Metadata */
 
-#gh-series-info-modal .gh-series-info-organiser {
+#gh-series-info-modal .gh-series-info-location {
     border-top-color: #AAA;
 }
 
-#gh-series-info-modal .gh-series-info-location {
+#gh-series-info-modal .gh-series-info-organiser {
     border-top-color: #DDD;
 }
 
+#gh-series-info-modal .gh-series-info-list-no-events,
 #gh-series-info-modal .gh-series-info-location,
 #gh-series-info-modal .gh-series-info-organiser {
     background-color: #EEE;

--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -56,6 +56,15 @@ define(['exports'], function(exports) {
     ////////////////
 
     /**
+     * Return the tripos structure
+     *
+     * @return {Object}    The tripos structure
+     */
+    var triposData = exports.triposData = function() {
+        return _triposData;
+    };
+
+    /**
      * Decorate an organisational unit with its parent info
      *
      * @param  {Object}    orgUnit    The organisational unit that needs to be decorated with his parent info

--- a/shared/gh/js/utils/gh.utils.templates.js
+++ b/shared/gh/js/utils/gh.utils.templates.js
@@ -79,7 +79,7 @@ define(['exports', 'gh.constants'], function(exports, constants) {
             'text!/shared/gh/partials/series-borrowed-popover.html',
             'text!/shared/gh/partials/series-borrowed-published-popover.html',
             'text!/shared/gh/partials/series-info.html',
-            'text!/shared/gh/partials/series-info-popover.html',
+            'text!/shared/gh/partials/series-info-modal.html',
             'text!/shared/gh/partials/student-module-item.html',
             'text!/shared/gh/partials/student-modules.html',
             'text!/shared/gh/partials/subheader-part.html',
@@ -139,4 +139,40 @@ define(['exports', 'gh.constants'], function(exports, constants) {
         // Always return the rendered HTML string
         return compiled;
     };
+
+    /**
+     * Render the hierarchy string
+     *
+     * @param  {Object}    orgUnit      The organisational unit to start building the hierarchy structure with
+     * @param  {String}    separator    The string used to split the organisational units
+     * @return {String}                 The generated hierarchy string
+     */
+    var renderHierarchyString = exports.renderHierarchyString = function(orgUnit, separator) {
+        if (!_.isObject(orgUnit)) {
+            throw new Error('An invalid value for orgUnit has been provided');
+        } else if (!_.isString(separator)) {
+            throw new Error('An invalid value for separator has been provided');
+        }
+
+        // Store the organisational units' display names
+        var hierarchy = [];
+
+        /**
+         * Retrieve the display name for each parent object in the tree structure
+         *
+         * @param  {Object}    The organisational unit to return the display name from
+         * @private
+         */
+        var _renderHierarchyString = function(orgUnit) {
+            hierarchy.push(orgUnit.displayName);
+            if (orgUnit.Parent) {
+                return _renderHierarchyString(orgUnit.Parent);
+            } else {
+                return hierarchy.reverse().join(separator);
+            }
+        };
+
+        // Start rendering the hierarchy string
+        return _renderHierarchyString(orgUnit);
+     };
 });

--- a/shared/gh/js/utils/gh.utils.templates.js
+++ b/shared/gh/js/utils/gh.utils.templates.js
@@ -141,7 +141,7 @@ define(['exports', 'gh.constants'], function(exports, constants) {
     };
 
     /**
-     * Render the hierarchy string
+     * Render and return the hierarchy string
      *
      * @param  {Object}    orgUnit      The organisational unit to start building the hierarchy structure with
      * @param  {String}    separator    The string used to split the organisational units
@@ -158,13 +158,15 @@ define(['exports', 'gh.constants'], function(exports, constants) {
         var hierarchy = [];
 
         /**
-         * Retrieve the display name for each parent object in the tree structure
+         * Retrieve the display name for each parent object in the tree structure and return
+         * the hierarchy string when no more parents are available
          *
-         * @param  {Object}    The organisational unit to return the display name from
+         * @param  {Object}             The organisational unit to return the display name from
+         * @return {Function|String}    The recursive function or the generated hierarchy string
          * @private
          */
         var _renderHierarchyString = function(orgUnit) {
-            hierarchy.push(orgUnit.displayName);
+            hierarchy.push('<span>' + orgUnit.displayName + '</span>');
             if (orgUnit.Parent) {
                 return _renderHierarchyString(orgUnit.Parent);
             } else {

--- a/shared/gh/js/views/gh.series-info.js
+++ b/shared/gh/js/views/gh.series-info.js
@@ -17,15 +17,15 @@ define(['gh.core', 'gh.constants', 'moment'], function(gh, constants, moment) {
 
     // Cache the retrieved series
     var series = {};
+    // The series ID to retrieve the events for
+    var seriesId = null;
 
     /**
      * Retrieve the series information
      *
-     * @param  {Number}    seriesId     The ID of the series that needs to be retrieved
      * @private
      */
-    var retrieveSeries = function(seriesId) {
-
+    var retrieveSeries = function() {
         // Fetch the series if it hasn't been retrieved yet
         if (!series[seriesId]) {
             return gh.api.seriesAPI.getSeries(seriesId, false, function(err, data) {
@@ -38,7 +38,7 @@ define(['gh.core', 'gh.constants', 'moment'], function(gh, constants, moment) {
 
                 // Skip the data retrieval if the events have already been cached
                 if (series[seriesId]['Events']) {
-                    return retrieveSeries(seriesId);
+                    return retrieveSeries();
                 }
 
                 // Retrieve the events that belong to the series
@@ -68,7 +68,7 @@ define(['gh.core', 'gh.constants', 'moment'], function(gh, constants, moment) {
                         if (data.results.length === 25) {
                             return _getSeriesEvents(offset += 25);
                         }
-                        return retrieveSeries(seriesId);
+                        return retrieveSeries();
                     });
                 };
 
@@ -168,7 +168,8 @@ define(['gh.core', 'gh.constants', 'moment'], function(gh, constants, moment) {
         var $trigger = $(this);
 
         // Store the series ID
-        var seriesId = $trigger.data('id');
+        seriesId = $trigger.data('id');
+
         // Retrieve the series title
         var seriesTitle = $trigger.closest('.list-group-item').find('.gh-list-description-text').html();
 
@@ -188,7 +189,7 @@ define(['gh.core', 'gh.constants', 'moment'], function(gh, constants, moment) {
         });
 
         // Generate the hierarchy string
-        var hierarchy = gh.utils.renderHierarchyString(parent, ' > ');
+        var hierarchy = gh.utils.renderHierarchyString(parent, '<i class="fa fa-angle-double-right"></i>');
 
         // Render the popover window
         gh.utils.renderTemplate($('#gh-series-info-modal-template'), {
@@ -197,11 +198,6 @@ define(['gh.core', 'gh.constants', 'moment'], function(gh, constants, moment) {
                 'seriesTitle': seriesTitle
             }
         }, $('#gh-modal'));
-
-        // Retrieve the series when the modal is shown
-        $('#gh-series-info-modal').on('shown.bs.modal', function(e) {
-            retrieveSeries(seriesId);
-        });
 
         // Show the modal
         $('#gh-series-info-modal').modal();
@@ -218,6 +214,8 @@ define(['gh.core', 'gh.constants', 'moment'], function(gh, constants, moment) {
      * @private
      */
     var addBinding = function() {
+        // Retrieve the series when the modal is shown
+        $('body').on('shown.bs.modal', '#gh-series-info-modal', retrieveSeries);
         // Set up and show the series info modal
         $('body').on('click', '.fa-info-circle', setUpModal);
     };

--- a/shared/gh/partials/series-info-modal.html
+++ b/shared/gh/partials/series-info-modal.html
@@ -6,9 +6,9 @@
                     <span aria-hidden="true">×</span>
                     <span class="sr-only">Close</span>
                 </button>
-                <h4 class="modal-title" id="modal-title"><%- data.seriesTitle %></h4>
+                <h4 class="modal-title" id="modal-title"><%= data.seriesTitle %></h4>
                 <% if (data.hierarchy) { %>
-                    <p><%- data.hierarchy %></p>
+                    <p class="gh-series-info-hierarchy"><%= data.hierarchy %></p>
                 <% } %>
             </div>
             <div class="modal-body">

--- a/shared/gh/partials/series-info-modal.html
+++ b/shared/gh/partials/series-info-modal.html
@@ -1,0 +1,24 @@
+<div class="modal fade" id="gh-series-info-modal" tabindex="-1" role="dialog" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close btn-reverse" data-dismiss="modal">
+                    <span aria-hidden="true">×</span>
+                    <span class="sr-only">Close</span>
+                </button>
+                <h4 class="modal-title" id="modal-title"><%- data.seriesTitle %></h4>
+                <% if (data.hierarchy) { %>
+                    <p><%- data.hierarchy %></p>
+                <% } %>
+            </div>
+            <div class="modal-body">
+                <div class="text-center gh-series-info-spinner">
+                    <i class="fa fa-spinner fa-spin"></i>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default pull-right" data-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/shared/gh/partials/series-info-popover.html
+++ b/shared/gh/partials/series-info-popover.html
@@ -1,7 +1,0 @@
-<div class="popover fade gh-series-popover info" role="tooltip" data-id="<%- data.id %>">
-    <div class="series-info-container">
-        <div class="text-center">
-            <i class="fa fa-spinner fa-spin"></i>
-        </div>
-    </div>
-</div>

--- a/shared/gh/partials/series-info.html
+++ b/shared/gh/partials/series-info.html
@@ -22,13 +22,16 @@
                     <% _.each(term.events, function(event) { %>
                         <div class="gh-series-info-list-event">
 
-                            <!-- Event type -->
-                            <div class="gh-event-type gh-series-info-list-event-type" data-type="<%- event.type %>" data-first="<% if (event.type) { %><%- event.type.substr(0,1) %><% } %>" title="<%- event.type %>"><% if (event.type) { %><span style="visibility: hidden;"><%- event.type %></span><% } %></div>
-
                             <!-- Event date -->
                             <div class="gh-series-info-list-event-date">
                                 <%= _.partial('admin-edit-date-field', {'data': event, 'utils': data.utils}) %>
                             </div>
+
+                            <!-- Event type -->
+                            <div class="gh-event-type gh-series-info-list-event-type" data-type="<%- event.type %>" data-first="<% if (event.type) { %><%- event.type.substr(0,1) %><% } %>" title="<%- event.type %>"><% if (event.type) { %><span style="visibility: hidden;"><%- event.type %></span><% } %></div>
+
+                            <!-- Event title -->
+                            <div class="gh-series-info-list-event-title"><%= event.displayName %></div>
                         </div>
                     <%}); %>
                 </div>
@@ -39,12 +42,15 @@
     <% } %>
 </div>
 
-<!-- Organisers -->
-<% if (data.organisers && data.organisers.length) { %>
-    <div class="gh-series-info-organiser"><%- data.organisers.join(', ') %></div>
-<% } %>
 
-<!-- Locations -->
-<% if (data.locations && data.locations.length) { %>
-    <div class="gh-series-info-location"><%- data.locations.join(', ') %></div>
+<% if (numEvents) { %>
+    <!-- Locations -->
+    <div class="gh-series-info-location">
+        <% if (data.locations && data.locations.length) { %><%- data.locations.join(', ') %><% } else { %>Location not known<% } %>
+    </div>
+
+    <!-- Organisers -->
+    <div class="gh-series-info-organiser">
+        <% if (data.organisers && data.organisers.length) { %><%- data.organisers.join(', ') %><% } else { %>Lecturer not known<% } %>
+    </div>
 <% } %>

--- a/shared/gh/partials/series-info.html
+++ b/shared/gh/partials/series-info.html
@@ -1,5 +1,3 @@
-<h3 class="gh-popover-title"><%- data.displayName %></h3>
-
 <%
     var numEvents = 0;
     _.each(_.map(data.terms, function(term) {
@@ -11,27 +9,42 @@
     });
 %>
 
-<div class="row">
+<!-- Series -->
+<div class="gh-series-info-list">
     <% if (numEvents) { %>
         <% _.each(data.terms, function(term) { %>
             <% if (term.events && term.events.length) { %>
-                <div class="col-sm-4">
-                    <strong class="term-name"><%- term.label %></strong>
+                <div class="gh-series-info-list-term">
+                    <!-- Term -->
+                    <strong><%- term.label %></strong>
+
+                    <!-- Event -->
                     <% _.each(term.events, function(event) { %>
-                        <p><%- data.utils.generateDisplayDate(event.start, event.end) %></p>
+                        <div class="gh-series-info-list-event">
+
+                            <!-- Event type -->
+                            <div class="gh-event-type gh-series-info-list-event-type" data-type="<%- event.type %>" data-first="<% if (event.type) { %><%- event.type.substr(0,1) %><% } %>" title="<%- event.type %>"><% if (event.type) { %><span style="visibility: hidden;"><%- event.type %></span><% } %></div>
+
+                            <!-- Event date -->
+                            <div class="gh-series-info-list-event-date">
+                                <%= _.partial('admin-edit-date-field', {'data': event, 'utils': data.utils}) %>
+                            </div>
+                        </div>
                     <%}); %>
                 </div>
             <% } %>
         <% }); %>
     <% } else { %>
-        <div class="col-sm-12">No events</div>
+        <div class="gh-series-info-list-no-events">No events</div>
     <% } %>
 </div>
 
+<!-- Organisers -->
 <% if (data.organisers && data.organisers.length) { %>
-    <p class="gh-popover-organiser"><%- data.organisers.join(', ') %></p>
+    <div class="gh-series-info-organiser"><%- data.organisers.join(', ') %></div>
 <% } %>
 
+<!-- Locations -->
 <% if (data.locations && data.locations.length) { %>
-    <p class="gh-popover-location"><%- data.locations.join(', ') %></p>
+    <div class="gh-series-info-location"><%- data.locations.join(', ') %></div>
 <% } %>

--- a/shared/gh/partials/student-module-item.html
+++ b/shared/gh/partials/student-module-item.html
@@ -17,9 +17,6 @@
                     </div>
             <% } %>
                     <% if (isChild) { %>
-                        <!-- Additional series info popover container -->
-                        <div class="gh-series-info-popover-container" data-id="<%- d.id %>"><!-- --></div>
-
                         <!-- Additional series info popover trigger -->
                         <div class="gh-list-info">
                             <i class="fa fa-info-circle" data-id="<%- d.id %>"></i>

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -940,6 +940,47 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
         assert.ok($('#qunit-template-partial-target').html(), 'Verify the template partial HTML is rendered in the target container');
     });
 
+    // Test the 'renderHierarchyString' functionality
+    QUnit.asyncTest('renderHierarchyString', function(assert) {
+        expect(6);
+
+        // Retrieve the tripos structure for the test app
+        var testApp = testAPI.getTestApp();
+        gh.utils.getTriposStructure(testApp.id, function(err, data) {
+            assert.ok(!err);
+
+            // Find an organisational unit that has parents
+            var orgUnitWithParents = _.find(data.parts, function(orgUnit) {
+                return orgUnit.ParentId !== null;
+            });
+
+            // Verify that an error is thrown when no orgUnit was provided
+            assert.throws(function() {
+                gh.utils.renderHierarchyString(null, '>');
+            }, 'Verify that an error is thrown when no orgUnit was provided');
+
+            // Verify that an error is thrown when an invalid orgUnit was provided
+            assert.throws(function() {
+                gh.utils.renderHierarchyString('invalid_object', '>');
+            }, 'Verify that an error is thrown when an invalid orgUnit was provided');
+
+            // Verify that an error is thrown when no separater was provided
+            assert.throws(function() {
+                gh.utils.renderHierarchyString(orgUnitWithParents, null);
+            }, 'Verify that an error is thrown when no separator was provided');
+
+            // Verify that an error is thrown when an invalid separator was provided
+            assert.throws(function() {
+                gh.utils.renderHierarchyString(orgUnitWithParents, 9999);
+            }, 'Verify that an error is thrown when an invalid separator was provided');
+
+            // Verify that the hierarchy string is returned when all the parameters have been provided
+            assert.ok(gh.utils.renderHierarchyString(orgUnitWithParents, ' > '));
+
+            QUnit.start();
+        });
+    });
+
 
     ////////////////
     //  TRIPOSES  //

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -1143,6 +1143,15 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
         });
     });
 
+    // Test the 'triposData' functionality
+    QUnit.test('triposData', function(assert) {
+        expect(3);
+        var _triposData = gh.utils.triposData();
+        assert.ok(_triposData);
+        assert.ok(_triposData.subjects);
+        assert.ok(_triposData.parts);
+    });
+
 
     //////////////////
     //  BATCH EDIT  //


### PR DESCRIPTION
I know the original design specified a tooltip, but now having actually used the info icon / info popup in the student UI, I think the comprehensive info should be lifted into a modal. This approach would also give a better handling of OT events than the column based approach.

Items:
* [x] Lift content into a modal. Invoke the modal when the info icon in the list is clicked or tapped.
* [x] Add scrollable event list with date info, in date order which would take care of OT event handling
* [x] Style dates as we do in the admin UI 
* [x] Add minimal series type info for each event, with tooltip explanation on hover (just basic)
* [x] Include tripos and part in the modal title
* [x] Concatenate all lecturers and venues at the bottom of the modal

![adj-student-series-info](https://cloud.githubusercontent.com/assets/117483/6997554/545d0840-dbb7-11e4-9e3b-5695b94fd654.png)


