### PR TITLE
Make sure structural elements don't animate when the page is being set up

### DIFF
--- a/apps/admin/ui/index.html
+++ b/apps/admin/ui/index.html
@@ -20,7 +20,7 @@
         <link rel="stylesheet" href="/apps/admin/ui/css/admin.css">
         <link rel='stylesheet' href="/shared/gh/css/gh.print.css" media="print">
     </head>
-    <body class="gh-global-admin">
+    <body class="gh-global-admin gh-preload">
         <div id="gh-page-container">
             <div id="gh-left-container">
                 <div id="gh-meta-container">

--- a/apps/timetable/admin/index.html
+++ b/apps/timetable/admin/index.html
@@ -41,7 +41,7 @@
         <link rel="stylesheet" href="/apps/timetable/admin/ui/css/skin.css">
         <link rel='stylesheet' href="/shared/gh/css/gh.print.css" media="print">
     </head>
-    <body class="gh-admin">
+    <body class="gh-admin gh-preload">
         <div id="gh-page-container">
             <div id="gh-left-container">
                 <div id="gh-meta-container">

--- a/apps/timetable/ui/index.html
+++ b/apps/timetable/ui/index.html
@@ -37,7 +37,7 @@
         <link rel="stylesheet" href="/shared/gh/css/gh.skin.css">
         <link rel='stylesheet' href="/shared/gh/css/gh.print.css" media="print">
     </head>
-    <body class="gh-student">
+    <body class="gh-student gh-preload">
         <div id="gh-page-container">
             <div id="gh-left-container">
                 <div id="gh-meta-container">

--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -85,6 +85,17 @@ select[disabled],
     width: 100%;
 }
 
+/* When the page loads and it's laying itself out, animations shouldn't occur.
+   The class gets removed after the page has been set up */
+.gh-preload {
+    -webkit-transition: none !important;
+       -moz-transition: none !important;
+        -ms-transition: none !important;
+         -o-transition: none !important;
+            transition: none !important;
+}
+
+
 /**************/
 /* VALIDATION */
 /**************/

--- a/shared/gh/js/gh.core.js
+++ b/shared/gh/js/gh.core.js
@@ -55,6 +55,11 @@ define([
 
     function(gh) {
 
+        // The UI uses a `gh-preload` class on the body to avoid structural elements animating during page setup.
+        // By the time the logic reaches this code the structural elements have been rendered and the class
+        // can be removed, allowing for animations in the page.
+        $('body').removeClass('gh-preload');
+
         // Globally catch ajax errors and track the error when it's an API call
         $(document).ajaxError(function(ev, jqXHR, ajaxSettings) {
             // Only track the error if it's an API call


### PR DESCRIPTION
When animating structural elements in a page it can happen that they animate on load as well. To fix this a class is added to the body (`gh-preload`) that disables all animations. Once the page has been set up the class is removed and animations can be applied.