### PR TITLE
Iron out remaining issues in batch date edit

### DIFF
--- a/shared/gh/js/utils/gh.utils.time.js
+++ b/shared/gh/js/utils/gh.utils.time.js
@@ -59,7 +59,7 @@ define(['exports', 'gh.constants', 'moment'], function(exports, constants, momen
         if (!date || !moment(date, 'x').isValid()) {
             throw new Error('An invalid value for date has been provided');
         }
-        return new Date(date).toISOString();
+        return moment(date).utc().format();
     };
 
     /**

--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -203,25 +203,29 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
                         // Create the end date of the event
                         var endDate = moment([eventYear, eventMonth, eventDay, eventEndHour, eventEndMinute, 0, 0]);
 
-                        $(document).trigger('gh.batchedit.addevent', {
-                            'eventContainer': $('.gh-batch-edit-events-container[data-term="' + termName + '"]').find('tbody'),
-                            'eventObj': {
-                                'tempId': gh.utils.generateRandomString(), // The actual ID hasn't been generated yet
-                                'isNew': true, // Used in the template to know this one needs special handling
-                                'selected': true,
-                                'displayName': $('.gh-jeditable-series-title').text(),
-                                'end': gh.utils.convertUnixDatetoISODate(moment(endDate).utc().format()),
-                                'location': defaultLocation,
-                                'type': gh.config.events.default,
-                                'organisers': defaultOrganisers,
-                                'start': gh.utils.convertUnixDatetoISODate(moment(startDate).utc().format())
-                            },
-                            'startDate': startDate
-                        });
+                        // Send off an event that will be picked up by the batch edit and add the rows to the terms
+                        var alreadyAdded = $('.gh-event-date[data-start="' + gh.utils.convertUnixDatetoISODate(moment(startDate).utc().format()) + '"]').length;
+                        if (!alreadyAdded) {
+                            $(document).trigger('gh.batchedit.addevent', {
+                                'eventContainer': $('.gh-batch-edit-events-container[data-term="' + termName + '"]').find('tbody'),
+                                'eventObj': {
+                                    'tempId': gh.utils.generateRandomString(), // The actual ID hasn't been generated yet
+                                    'isNew': true, // Used in the template to know this one needs special handling
+                                    'selected': true,
+                                    'displayName': $('.gh-jeditable-series-title').text(),
+                                    'end': gh.utils.convertUnixDatetoISODate(moment(endDate).utc().format()),
+                                    'location': defaultLocation,
+                                    'type': gh.config.events.default,
+                                    'organisers': defaultOrganisers,
+                                    'start': gh.utils.convertUnixDatetoISODate(moment(startDate).utc().format())
+                                },
+                                'startDate': startDate
+                            });
 
-                        // Update processing progress indication
-                        currentEvent = currentEvent + 1;
-                        updateEventManipulationProgress(currentEvent, totalEvents);
+                            // Update processing progress indication
+                            currentEvent = currentEvent + 1;
+                            updateEventManipulationProgress(currentEvent, totalEvents);
+                        }
                     }
                 });
             });

--- a/shared/gh/js/views/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-date.js
@@ -274,7 +274,6 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
 
         // Keep track of progress
         var totalEvents = $('#gh-batch-edit-date-picker-container').data('terms').split(',').length * $weeks.length * $days.length;
-
         var currentEvent = 0;
 
         // For each term selected, add events
@@ -322,7 +321,7 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
                             var endDate = moment([eventYear, eventMonth, eventDay, eventEndHour, eventEndMinute, 0, 0]);
 
                             // Send off an event that will be picked up by the batch edit and add the rows to the terms
-                            var alreadyAdded = $('.gh-event-date[data-start="' + gh.utils.convertUnixDatetoISODate(moment(startDate).utc().format()) + '"]').length;
+                            var alreadyAdded = $('.gh-event-date[data-start="' + moment(startDate).utc().format() + '"]').length;
                             if (!alreadyAdded || forceAdd) {
                                 $(document).trigger('gh.batchedit.addevent', {
                                     'eventContainer': $('.gh-batch-edit-events-container[data-term="' + termName + '"]').find('tbody'),
@@ -592,8 +591,8 @@ define(['lodash', 'moment', 'gh.core', 'gh.api.config'], function(_, moment, gh,
 
                     // Retrieve and calculate the event dates
                     var newDateYear = moment(newDate).utc().format('YYYY');
-                    var newDateMonth = moment(newDate).subtract({'months': 1}).utc().format('MM');
-                    var newDateDay = moment(newDate).utc().format('DD');
+                    var newDateMonth = parseInt(moment(newDate).utc().format('MM'), 10) - 1;
+                    var newDateDay = moment(newDate).add({'hours': 1}).utc().format('DD');
 
                     // Create the new date for the row
                     eventStart = moment([newDateYear, newDateMonth, newDateDay, eventStartHour, eventStartMinute, 0, 0]).utc().format();

--- a/shared/gh/js/views/gh.datepicker.js
+++ b/shared/gh/js/views/gh.datepicker.js
@@ -20,8 +20,10 @@ define(['gh.core', 'moment', 'clickover', 'jquery-datepicker'], function(gh, mom
     var hasChanges = false;
 
     var _term = null;
+
     // Keep track of when the user started
     var timeFromStart = null;
+
 
     /////////////////
     //  UTILITIES  //


### PR DESCRIPTION
- [x] When an empty term is selected and any week (except 1) is clicked, the new event is always added to week 1. This doesn't happen when an event was already present.

- [x] When an event has been added on a date, the user clicks 'add another day' and selects that same day of the week, that event gets duplicated in the list. We should avoid adding 2 events on the same day of the same week through batch edit.

This is part of followup for https://github.com/CUL-DigitalServices/grasshopper-ui/pull/343