### PR TITLE
Admin UI to manage application users

### DIFF
--- a/apps/admin/ui/css/admin.css
+++ b/apps/admin/ui/css/admin.css
@@ -67,7 +67,12 @@ table {
 
 .gh-administration-container .panel-default .panel-body .panel-subheading {
     font-weight: 600;
+    padding-top: 10px;
     text-align: center;
+}
+
+#gh-administrators-container .panel-default > .panel-heading + .panel-collapse > .panel-body {
+    padding: 0 15px;
 }
 
 /* Striped rows */
@@ -89,7 +94,7 @@ table {
     width: 12px;
 }
 
-.gh-administration-container .gh-striped-row select {
+.gh-administration-container .gh-striped-row p {
     margin: 10px auto;
     width: 100%;
 }

--- a/apps/admin/ui/css/admin.css
+++ b/apps/admin/ui/css/admin.css
@@ -54,6 +54,13 @@ table {
     margin-bottom: 0;
 }
 
+.gh-administration-container .panel-default .panel-heading h4.panel-title::after,
+.gh-administration-container .panel-default .panel-heading span::after {
+    clear: both;
+    content: '';
+    display: block;
+}
+
 .gh-administration-container .panel-default .panel-body {
     padding-bottom: 0;
 }
@@ -82,6 +89,11 @@ table {
     width: 12px;
 }
 
+.gh-administration-container .gh-striped-row select {
+    margin: 10px auto;
+    width: 100%;
+}
+
 .gh-administration-container .gh-striped-row input[type="text"],
 .gh-administration-container .gh-striped-row input[type="password"] {
     height: 39px;
@@ -92,3 +104,17 @@ table {
     width: 100%;
 }
 
+/* Search */
+
+.gh-administration-container .panel-default .panel-heading .gh-striped-container-search + h4 {
+    line-height: 2.1;
+}
+
+.gh-administration-container .panel-default .panel-heading .gh-striped-container-search {
+    width: 400px;
+}
+
+.gh-administration-container .panel-default .panel-heading .gh-striped-container-search button {
+    height: 34px;
+    padding: 6px 12px;
+}

--- a/apps/admin/ui/index.html
+++ b/apps/admin/ui/index.html
@@ -213,6 +213,25 @@
         </script>
 
         <script id="gh-app-user-template" type="text/template">
+            <% if (app.config.allowLocalAccountCreation) { %>
+                <div class="panel-subheading row">
+                    <div class="gh-striped-heading col-sm-3">User name</div>
+                    <div class="gh-striped-heading col-sm-2">User username</div>
+                    <div class="gh-striped-heading col-sm-2">User password</div>
+                    <div class="gh-striped-heading col-sm-1">Admin</div>
+                    <div class="gh-striped-heading col-sm-2">Info</div>
+                    <div class="gh-striped-heading col-sm-2">Actions</div>
+                </div>
+            <% } %>
+
+            <% if (users.length === 0) { %>
+                <div class="gh-striped-row row">
+                    <div class="col-sm-3">
+                        <p>This app has no users<p>
+                    </div>
+                </div>
+            <% } %>
+
             <% _.each(users, function(user) { %>
                 <div class="gh-striped-row row">
                     <form class="gh-app-user-update-form" data-userid="<%- user.id %>">
@@ -241,6 +260,30 @@
                     </form>
                 </div>
             <% }); %>
+            <% if (app.config.allowLocalAccountCreation) { %>
+                <div class="gh-striped-row row">
+                    <form class="gh-app-user-create-form" data-appid="<%- app.id %>">
+                        <div class="col-sm-3">
+                            <input class="gh-new-user-displayname" type="text" placeholder="New user name">
+                        </div>
+                        <div class="col-sm-2">
+                            <input class="gh-new-user-email" type="text" placeholder="New user email">
+                        </div>
+                        <div class="col-sm-2">
+                            <input class="gh-new-user-password" type="password" placeholder="New user password">
+                        </div>
+                        <div class="col-sm-1">
+                            <input class="gh-new-user-isadmin" type="checkbox"/>
+                        </div>
+                        <div class="col-sm-2">
+
+                        </div>
+                        <div class="col-sm-2">
+                            <button type="submit" class="btn btn-success">Create user</button>
+                        </div>
+                    </form>
+                </div>
+            <% } %>
         </script>
 
         <script id="gh-app-users-template" type="text/template">
@@ -266,36 +309,38 @@
                             </div>
                             <div id="<%= randomId %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="<%- randomId %>-heading">
                                 <div class="panel-body">
-                                    <div class="panel-subheading row">
-                                        <div class="gh-striped-heading col-sm-3">User name</div>
-                                        <div class="gh-striped-heading col-sm-2">User username</div>
-                                        <div class="gh-striped-heading col-sm-2">User password</div>
-                                        <div class="gh-striped-heading col-sm-1">Admin</div>
-                                        <div class="gh-striped-heading col-sm-2">Info</div>
-                                        <div class="gh-striped-heading col-sm-2">Actions</div>
-                                    </div>
-                                    <div class="gh-users-container"><!-- --></div>
-                                    <div class="gh-striped-row row">
-                                        <form class="gh-app-user-create-form" data-appid="<%- app.id %>">
-                                            <div class="col-sm-3">
-                                                <input class="gh-new-user-displayname" type="text" placeholder="New user name">
-                                            </div>
-                                            <div class="col-sm-2">
-                                                <input class="gh-new-user-email" type="text" placeholder="New user email">
-                                            </div>
-                                            <div class="col-sm-2">
-                                                <input class="gh-new-user-password" type="password" placeholder="New user password">
-                                            </div>
-                                            <div class="col-sm-1">
-                                                <input class="gh-new-user-isadmin" type="checkbox"/>
-                                            </div>
-                                            <div class="col-sm-2">
+                                    <div class="gh-users-container">
+                                        <div class="panel-subheading row">
+                                            <div class="gh-striped-heading col-sm-3">User name</div>
+                                            <div class="gh-striped-heading col-sm-2">User username</div>
+                                            <div class="gh-striped-heading col-sm-2">User password</div>
+                                            <div class="gh-striped-heading col-sm-1">Admin</div>
+                                            <div class="gh-striped-heading col-sm-2">Info</div>
+                                            <div class="gh-striped-heading col-sm-2">Actions</div>
+                                        </div>
 
+                                        <% if (app.config.allowLocalAccountCreation) { %>
+                                            <div class="gh-striped-row row">
+                                                <form class="gh-app-user-create-form" data-appid="<%- app.id %>">
+                                                    <div class="col-sm-3">
+                                                        <input class="gh-new-user-displayname" type="text" placeholder="New user name">
+                                                    </div>
+                                                    <div class="col-sm-2">
+                                                        <input class="gh-new-user-email" type="text" placeholder="New user email">
+                                                    </div>
+                                                    <div class="col-sm-2">
+                                                        <input class="gh-new-user-password" type="password" placeholder="New user password">
+                                                    </div>
+                                                    <div class="col-sm-1">
+                                                        <input class="gh-new-user-isadmin" type="checkbox"/>
+                                                    </div>
+                                                    <div class="col-sm-2"></div>
+                                                    <div class="col-sm-2">
+                                                        <button type="submit" class="btn btn-success">Create user</button>
+                                                    </div>
+                                                </form>
                                             </div>
-                                            <div class="col-sm-2">
-                                                <button type="submit" class="btn btn-success">Create user</button>
-                                            </div>
-                                        </form>
+                                        <% } %>
                                     </div>
                                 </div>
                             </div>

--- a/apps/admin/ui/index.html
+++ b/apps/admin/ui/index.html
@@ -229,10 +229,11 @@
                             <input class="gh-user-isadmin" type="checkbox"<% if (user.isAdmin) { %> checked<% } %>/>
                         </div>
                         <div class="col-sm-2">
-                            <select class="gh-user-emailpreference">
-                                <option value="immediate" <% if (user.emailPreference === 'immediate') { %> selected="true" <% } %>>Immediate email</option>
-                                <option value="no" <% if (user.emailPreference === 'no') { %> selected="true" <% } %>>No email</option>
-                            </select>
+                            <% if (user.shibbolethId) { %>
+                                <input class="gh-user-shibbolethid" type="text" placeholder="Shibboleth ID" disabled value="<%- user.shibbolethId %>">
+                            <% } else { %>
+                                <p class="text-center">Local account</p>
+                            <% } %>
                         </div>
                         <div class="col-sm-2">
                             <button type="submit" class="btn btn-primary">Update user</button>
@@ -270,7 +271,7 @@
                                         <div class="gh-striped-heading col-sm-2">User username</div>
                                         <div class="gh-striped-heading col-sm-2">User password</div>
                                         <div class="gh-striped-heading col-sm-1">Admin</div>
-                                        <div class="gh-striped-heading col-sm-2">Email</div>
+                                        <div class="gh-striped-heading col-sm-2">Info</div>
                                         <div class="gh-striped-heading col-sm-2">Actions</div>
                                     </div>
                                     <div class="gh-users-container"><!-- --></div>
@@ -289,10 +290,7 @@
                                                 <input class="gh-new-user-isadmin" type="checkbox"/>
                                             </div>
                                             <div class="col-sm-2">
-                                                <select class="gh-new-user-emailpreference">
-                                                    <option value="immediate">Immediate email</option>
-                                                    <option value="no">No email</option>
-                                                </select>
+
                                             </div>
                                             <div class="col-sm-2">
                                                 <button type="submit" class="btn btn-success">Create user</button>

--- a/apps/admin/ui/index.html
+++ b/apps/admin/ui/index.html
@@ -39,177 +39,272 @@
                     <div id="gh-subheader"></div>
                 </div>
                 <main id="gh-main">
-                    <div id="gh-configuration-container" style="display: none;"><!-- --></div>
-                    <div id="gh-tenants-container" style="display: none;"><!-- --></div>
-                    <div id="gh-administrators-container" style="display: none;"><!-- --></div>
+                    <div id="gh-configuration-container" class="gh-administration-container" style="display: none;"><!-- --></div>
+                    <div id="gh-tenants-container" class="gh-administration-container" style="display: none;"><!-- --></div>
+                    <div id="gh-administrators-container" class="gh-administration-container" style="display: none;">
+                        <h1>Users</h1>
+                        <div id="gh-global-users-container"><!-- --></div>
+                        <div id="gh-app-users-container"><!-- --></div>
+                    </div>
                 </main>
             </div>
             <div class="clearfix"></div>
         </div>
 
         <script id="gh-configuration-template" type="text/template">
-            <div class="gh-administration-container">
-                <h1>Configuration</h1>
-                <% _.each(tenants, function(tenant) { %>
-                    <% _.each(tenant.apps, function(app) { %>
-                        <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-                            <div class="panel panel-default">
-                                <div class="panel-heading" role="tab" id="headingOne">
-                                    <h4 class="panel-title">
-                                        <% var randomId = gh.utils.generateRandomString(true); %>
-                                        <a data-toggle="collapse" data-parent="#accordion" href="#<%= randomId %>" aria-expanded="false" aria-controls="<%= randomId %>">
-                                            <%- tenant.displayName %> - <%- app.displayName %> - <%- app.host %>
-                                        </a>
-                                    </h4>
-                                </div>
-                                <div id="<%= randomId %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
-                                    <div class="panel-body">
-                                        <form role="form" class="gh-configuration-form" data-appid="<%= app.id %>">
-                                            <% _.each(app.config, function(value, option) { %>
-                                                <% if (option === 'AppId' || option === 'terms' || option === 'events') { return; }%>
-                                                <% if (typeof value === 'boolean') { %>
-                                                    <div class="checkbox">
-                                                        <label>
-                                                            <input type="checkbox" name="<%= option %>" value="<%= value %>" <% if (value === true) { %> checked<% } %>> <%= option %>
-                                                        </label>
-                                                    </div>
-                                                <% } else { %>
-                                                    <div class="form-group">
-                                                        <label for="<%= option %>"><%= option %></label>
-                                                        <input type="text" class="form-control" id="<%= option %>" value="<%= value %>" name="<%= option %>">
-                                                    </div>
-                                                <% } %>
-                                            <% }) %>
-                                            <button type="submit" class="btn btn-success">Update configuration</button>
-                                        </form>
-                                    </div>
-                                </div>
+            <h1>Configuration</h1>
+            <% _.each(tenants, function(tenant) { %>
+                <% _.each(tenant.apps, function(app) { %>
+                    <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+                        <div class="panel panel-default">
+                            <div class="panel-heading" role="tab" id="headingOne">
+                                <h4 class="panel-title">
+                                    <% var randomId = gh.utils.generateRandomString(true); %>
+                                    <a data-toggle="collapse" data-parent="#accordion" href="#<%= randomId %>" aria-expanded="false" aria-controls="<%= randomId %>">
+                                        <%- tenant.displayName %> - <%- app.displayName %> - <%- app.host %>
+                                    </a>
+                                </h4>
                             </div>
-                        </div>
-                    <% }) %>
-                <% }) %>
-            </div>
-        </script>
-
-        <script id="gh-tenants-template" type="text/template">
-            <div class="gh-administration-container">
-                <h1>Tenants and Apps</h1>
-
-                <h2>Create a new tenant</h2>
-                <form id="gh-tenants-create-tenant-form">
-                    <div class="form-group">
-                        <label for="gh-tenant-name" class="control-label">Tenant display name</label>
-                        <input type="text" id="gh-tenant-name" class="form-control" placeholder="New tenant name"/>
-                    </div>
-                    <button type="submit" class="btn btn-default">Create tenant</button>
-                </form>
-
-                <h2>Tenants in the system</h2>
-                <% _.each(tenants, function(tenant) { %>
-                    <div class="panel-default gh-striped-container">
-                        <h3 class="panel-heading"><%- tenant.displayName %></h3>
-                        <div class="panel-body">
-                            <div class="panel-subheading row">
-                                <div class="gh-striped-heading col-sm-3">App name</div>
-                                <div class="gh-striped-heading col-sm-3">App host</div>
-                                <div class="gh-striped-heading col-sm-2">App enabled</div>
-                                <div class="gh-striped-heading col-sm-4">Actions</div>
-                            </div>
-                            <% _.each(tenant.apps, function(app) { %>
-                                <div class="gh-striped-row row">
-                                    <form class="gh-tenants-app-update-form" data-appid="<%- app.id %>">
-                                        <div class="col-sm-3">
-                                            <input class="gh-app-displayname" type="text" placeholder="App name" value="<%- app.displayName %>"/>
-                                        </div>
-                                        <div class="col-sm-3">
-                                            <input class="gh-app-host" type="text" placeholder="App host" value="<%- app.host %>"/>
-                                        </div>
-                                        <div class="col-sm-2">
-                                            <input class="gh-app-enabled" type="checkbox"<% if (app.enabled) { %> checked<% } %>/>
-                                        </div>
-                                        <div class="col-sm-2">
-                                            <button type="submit" class="btn btn-primary pull-left">Update app</button>
-                                        </div>
-                                        <div class="col-sm-2">
-                                            <a href="//<%- app.host %>" target="_blank" class="btn btn-info pull-left"><i class="fa fa-external-link"></i> Open app</a>
-                                        </div>
+                            <div id="<%= randomId %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                                <div class="panel-body">
+                                    <form role="form" class="gh-configuration-form" data-appid="<%= app.id %>">
+                                        <% _.each(app.config, function(value, option) { %>
+                                            <% if (option === 'AppId' || option === 'terms' || option === 'events') { return; }%>
+                                            <% if (typeof value === 'boolean') { %>
+                                                <div class="checkbox">
+                                                    <label>
+                                                        <input type="checkbox" name="<%= option %>" value="<%= value %>" <% if (value === true) { %> checked<% } %>> <%= option %>
+                                                    </label>
+                                                </div>
+                                            <% } else { %>
+                                                <div class="form-group">
+                                                    <label for="<%= option %>"><%= option %></label>
+                                                    <input type="text" class="form-control" id="<%= option %>" value="<%= value %>" name="<%= option %>">
+                                                </div>
+                                            <% } %>
+                                        <% }); %>
+                                        <button type="submit" class="btn btn-success">Update configuration</button>
                                     </form>
                                 </div>
-                            <% }); %>
-                            <div class="gh-striped-row row">
-                                <form class="gh-tenants-app-create-form" data-tenantid="<%- tenant.id %>">
-                                    <div class="col-sm-3">
-                                        <input class="gh-app-displayname" type="text" placeholder="New app name"/>
-                                    </div>
-                                    <div class="col-sm-3">
-                                        <input class="gh-app-host" type="text" placeholder="New app host"/>
-                                    </div>
-                                    <div class="col-sm-2">
-                                        <input class="gh-app-enabled" type="checkbox" checked disabled/>
-                                    </div>
-                                    <div class="col-sm-4">
-                                        <button type="submit" class="btn btn-success pull-left">Create app</button>
-                                    </div>
-                                </form>
                             </div>
                         </div>
                     </div>
                 <% }); %>
-            </div>
+            <% }); %>
         </script>
 
-        <script id="gh-administrators-template" type="text/template">
-            <div class="gh-administration-container">
-                <h1>Users</h1>
+        <script id="gh-tenants-template" type="text/template">
+            <h1>Tenants and Apps</h1>
+
+            <h2>Create a new tenant</h2>
+            <form id="gh-tenants-create-tenant-form">
+                <div class="form-group">
+                    <label for="gh-tenant-name" class="control-label">Tenant display name</label>
+                    <input type="text" id="gh-tenant-name" class="form-control" placeholder="New tenant name"/>
+                </div>
+                <button type="submit" class="btn btn-default">Create tenant</button>
+            </form>
+
+            <h2>Tenants in the system</h2>
+            <% _.each(tenants, function(tenant) { %>
                 <div class="panel-default gh-striped-container">
-                    <h3 class="panel-heading">Administrators in the system</h3>
+                    <h3 class="panel-heading"><%- tenant.displayName %></h3>
                     <div class="panel-body">
                         <div class="panel-subheading row">
-                            <div class="gh-striped-heading col-sm-3">Admin name</div>
-                            <div class="gh-striped-heading col-sm-2">Admin username</div>
-                            <div class="gh-striped-heading col-sm-3">Admin password</div>
+                            <div class="gh-striped-heading col-sm-3">App name</div>
+                            <div class="gh-striped-heading col-sm-3">App host</div>
+                            <div class="gh-striped-heading col-sm-2">App enabled</div>
                             <div class="gh-striped-heading col-sm-4">Actions</div>
                         </div>
-                        <% _.each(administrators, function(admin) { %>
+                        <% _.each(tenant.apps, function(app) { %>
                             <div class="gh-striped-row row">
-                                <form class="gh-administrators-update-form" data-userid="<%- admin.id %>">
+                                <form class="gh-tenants-app-update-form" data-appid="<%- app.id %>">
                                     <div class="col-sm-3">
-                                        <input id="gh-admin-displayname" type="text" placeholder="Administrator name" value="<%- admin.displayName %>"/>
-                                    </div>
-                                    <div class="col-sm-2">
-                                        <input id="gh-admin-username" type="text" placeholder="Administrator username" value="<%- admin.username %>" disabled/>
+                                        <input class="gh-app-displayname" type="text" placeholder="App name" value="<%- app.displayName %>"/>
                                     </div>
                                     <div class="col-sm-3">
-                                        <input id="gh-admin-password" type="password" placeholder="Administrator password" value="<%- admin.password %>"/>
+                                        <input class="gh-app-host" type="text" placeholder="App host" value="<%- app.host %>"/>
                                     </div>
                                     <div class="col-sm-2">
-                                        <button type="submit" class="btn btn-primary">Update</button>
+                                        <input class="gh-app-enabled" type="checkbox"<% if (app.enabled) { %> checked<% } %>/>
                                     </div>
                                     <div class="col-sm-2">
-                                        <button type="button" class="btn btn-danger gh-administrators-delete" data-userid="<%- admin.id %>">Delete</button>
+                                        <button type="submit" class="btn btn-primary pull-left">Update app</button>
+                                    </div>
+                                    <div class="col-sm-2">
+                                        <a href="//<%- app.host %>" target="_blank" class="btn btn-info pull-left"><i class="fa fa-external-link"></i> Open app</a>
                                     </div>
                                 </form>
                             </div>
                         <% }); %>
                         <div class="gh-striped-row row">
-                            <form id="gh-administrators-create-form">
+                            <form class="gh-tenants-app-create-form" data-tenantid="<%- tenant.id %>">
                                 <div class="col-sm-3">
-                                    <input id="gh-admin-displayname" type="text" placeholder="New administrator name"/>
+                                    <input class="gh-app-displayname" type="text" placeholder="New app name"/>
+                                </div>
+                                <div class="col-sm-3">
+                                    <input class="gh-app-host" type="text" placeholder="New app host"/>
                                 </div>
                                 <div class="col-sm-2">
-                                    <input id="gh-admin-username" type="text" placeholder="New administrator username"/>
-                                </div>
-                                <div class="col-sm-3">
-                                    <input id="gh-admin-password" type="password" placeholder="New administrator password"/>
+                                    <input class="gh-app-enabled" type="checkbox" checked disabled/>
                                 </div>
                                 <div class="col-sm-4">
-                                    <button type="submit" class="btn btn-success">Create administrator</button>
+                                    <button type="submit" class="btn btn-success pull-left">Create app</button>
                                 </div>
                             </form>
                         </div>
                     </div>
                 </div>
+            <% }); %>
+        </script>
+
+        <script id="gh-administrators-template" type="text/template">
+            <h2>Global administrators</h2>
+            <div class="panel-default gh-striped-container">
+                <h3 class="panel-heading">
+                    <span>Global administrators</span>
+                </h3>
+                <div class="panel-body">
+                    <div class="panel-subheading row">
+                        <div class="gh-striped-heading col-sm-3">Admin name</div>
+                        <div class="gh-striped-heading col-sm-2">Admin username</div>
+                        <div class="gh-striped-heading col-sm-3">Admin password</div>
+                        <div class="gh-striped-heading col-sm-4">Actions</div>
+                    </div>
+                    <% _.each(administrators, function(admin) { %>
+                        <div class="gh-striped-row row">
+                            <form class="gh-administrators-update-form" data-userid="<%- admin.id %>">
+                                <div class="col-sm-3">
+                                    <input id="gh-admin-displayname" type="text" placeholder="Administrator name" value="<%- admin.displayName %>"/>
+                                </div>
+                                <div class="col-sm-2">
+                                    <input id="gh-admin-username" type="text" placeholder="Administrator username" value="<%- admin.username %>" disabled/>
+                                </div>
+                                <div class="col-sm-3">
+                                    <input id="gh-admin-password" type="password" placeholder="Administrator password"/>
+                                </div>
+                                <div class="col-sm-2">
+                                    <button type="submit" class="btn btn-primary">Update</button>
+                                </div>
+                                <div class="col-sm-2">
+                                    <button type="button" class="btn btn-danger gh-administrators-delete" data-userid="<%- admin.id %>" <% if (administrators.length === 1) { %>disabled<% } %>>Delete</button>
+                                </div>
+                            </form>
+                        </div>
+                    <% }); %>
+                    <div class="gh-striped-row row">
+                        <form id="gh-administrators-create-form">
+                            <div class="col-sm-3">
+                                <input id="gh-admin-displayname" type="text" placeholder="New administrator name"/>
+                            </div>
+                            <div class="col-sm-2">
+                                <input id="gh-admin-username" type="text" placeholder="New administrator username"/>
+                            </div>
+                            <div class="col-sm-3">
+                                <input id="gh-admin-password" type="password" placeholder="New administrator password"/>
+                            </div>
+                            <div class="col-sm-4">
+                                <button type="submit" class="btn btn-success">Create administrator</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
             </div>
+        </script>
+
+        <script id="gh-app-user-template" type="text/template">
+            <% _.each(users, function(user) { %>
+                <div class="gh-striped-row row">
+                    <form class="gh-app-user-update-form" data-userid="<%- user.id %>">
+                        <div class="col-sm-3">
+                            <input class="gh-user-displayname" type="text" placeholder="User name" value="<%- user.displayName %>">
+                        </div>
+                        <div class="col-sm-2">
+                            <input class="gh-user-email" type="text" placeholder="User email" value="<%- user.email %>">
+                        </div>
+                        <div class="col-sm-2">
+                            <input class="gh-user-password" type="password" placeholder="User password" disabled>
+                        </div>
+                        <div class="col-sm-1">
+                            <input class="gh-user-isadmin" type="checkbox"<% if (user.isAdmin) { %> checked<% } %>/>
+                        </div>
+                        <div class="col-sm-2">
+                            <select class="gh-user-emailpreference">
+                                <option value="immediate" <% if (user.emailPreference === 'immediate') { %> selected="true" <% } %>>Immediate email</option>
+                                <option value="no" <% if (user.emailPreference === 'no') { %> selected="true" <% } %>>No email</option>
+                            </select>
+                        </div>
+                        <div class="col-sm-2">
+                            <button type="submit" class="btn btn-primary">Update user</button>
+                        </div>
+                    </form>
+                </div>
+            <% }); %>
+        </script>
+
+        <script id="gh-app-users-template" type="text/template">
+            <h2>App users</h2>
+
+            <% _.each(tenants, function(tenant) { %>
+                <% _.each(tenant.apps, function(app) { %>
+                    <% var randomId = gh.utils.generateRandomString(true); %>
+                    <div class="panel-group" id="<%- randomId %>-accordion" role="tablist" aria-multiselectable="true" data-appid="<%- app.id %>">
+                        <div class="panel panel-default">
+                            <div class="panel-heading" role="tab" id="<%- randomId %>-heading">
+                                <form id="gh-users-search-form" class="gh-striped-container-search form-inline pull-right">
+                                    <div class="form-group col-sm-9">
+                                        <input type="text" class="form-control" id="gh-administration-search" placeholder="Search users">
+                                    </div>
+                                    <button type="submit" class="btn btn-default col-sm-3">Search</button>
+                                </form>
+                                <h4 class="panel-title">
+                                    <a data-toggle="collapse" data-parent="#<%- randomId %>-accordion" href="#<%= randomId %>" aria-expanded="false" aria-controls="<%= randomId %>">
+                                        <%- tenant.displayName %> - <%- app.displayName %> - <%- app.host %>
+                                    </a>
+                                </h4>
+                            </div>
+                            <div id="<%= randomId %>" class="panel-collapse collapse" role="tabpanel" aria-labelledby="<%- randomId %>-heading">
+                                <div class="panel-body">
+                                    <div class="panel-subheading row">
+                                        <div class="gh-striped-heading col-sm-3">User name</div>
+                                        <div class="gh-striped-heading col-sm-2">User username</div>
+                                        <div class="gh-striped-heading col-sm-2">User password</div>
+                                        <div class="gh-striped-heading col-sm-1">Admin</div>
+                                        <div class="gh-striped-heading col-sm-2">Email</div>
+                                        <div class="gh-striped-heading col-sm-2">Actions</div>
+                                    </div>
+                                    <div class="gh-users-container"><!-- --></div>
+                                    <div class="gh-striped-row row">
+                                        <form class="gh-app-user-create-form" data-appid="<%- app.id %>">
+                                            <div class="col-sm-3">
+                                                <input class="gh-new-user-displayname" type="text" placeholder="New user name">
+                                            </div>
+                                            <div class="col-sm-2">
+                                                <input class="gh-new-user-email" type="text" placeholder="New user email">
+                                            </div>
+                                            <div class="col-sm-2">
+                                                <input class="gh-new-user-password" type="password" placeholder="New user password">
+                                            </div>
+                                            <div class="col-sm-1">
+                                                <input class="gh-new-user-isadmin" type="checkbox"/>
+                                            </div>
+                                            <div class="col-sm-2">
+                                                <select class="gh-new-user-emailpreference">
+                                                    <option value="immediate">Immediate email</option>
+                                                    <option value="no">No email</option>
+                                                </select>
+                                            </div>
+                                            <div class="col-sm-2">
+                                                <button type="submit" class="btn btn-success">Create user</button>
+                                            </div>
+                                        </form>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                <% }); %>
+            <% }); %>
         </script>
 
         <script id="gh-navigation-template" type="text/template">

--- a/apps/admin/ui/js/index.js
+++ b/apps/admin/ui/js/index.js
@@ -581,7 +581,7 @@ define(['gh.core', 'gh.constants', 'chosen', 'validator'], function(gh, constant
         var displayName = $('.gh-new-user-displayname', $form).val();
         var email = $('.gh-new-user-email', $form).val();
         var password = $('.gh-new-user-password', $form).val();
-        var emailPreference = $('.gh-new-user-emailpreference', $form).val();
+        var emailPreference = 'no';
         var isAdmin = $('.gh-new-user-isadmin', $form).is(':checked');
 
         // Create the administrator
@@ -614,7 +614,7 @@ define(['gh.core', 'gh.constants', 'chosen', 'validator'], function(gh, constant
         var userId = parseInt($form.data('userid'), 10);
         var displayName = $('.gh-user-displayname', $form).val();
         var email = $('.gh-user-email', $form).val();
-        var emailPreference = $('.gh-user-emailpreference', $form).val();
+        var emailPreference = 'no';
         var password = $('.gh-user-password', $form).val();
         var isAdmin = $('.gh-user-isadmin', $form).is(':checked');
 

--- a/shared/gh/js/controllers/gh.api.user.js
+++ b/shared/gh/js/controllers/gh.api.user.js
@@ -474,7 +474,19 @@ define(['exports'], function(exports) {
             return callback({'code': 400, 'msg': 'A valid value for isAdmin should be provided'});
         }
 
-        return callback();
+        $.ajax({
+            'url': '/api/users/' + userId + '/admin',
+            'type': 'POST',
+            'data': {
+                'admin': isAdmin
+            },
+            'success': function(data) {
+                return callback(null, data);
+            },
+            'error': function(jqXHR, textStatus) {
+                return callback({'code': jqXHR.status, 'msg': jqXHR.responseText});
+            }
+        });
     };
 
     /**

--- a/tests/qunit/tests/js/api.user.js
+++ b/tests/qunit/tests/js/api.user.js
@@ -716,7 +716,7 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
     // Test the updateAdminStatus functionality
     QUnit.asyncTest('updateAdminStatus', function(assert) {
-        expect(4);
+        expect(8);
 
         // Create a new user
         _generateRandomUser(function(err, user) {
@@ -737,15 +737,18 @@ require(['gh.core', 'gh.api.tests'], function(gh, testAPI) {
 
                     // Verify that the admin status can be updated without errors
                     gh.api.userAPI.updateAdminStatus(user.id, true, function(err, data) {
-
-                        /**
-                         * TODO: wait for back-end implementation
-                         *
                         assert.ok(!err, 'Verify that the admin status can be updated without errors');
-                        assert.ok(data, 'Verify that the updated user is returned');
-                         */
+                        assert.strictEqual(data.isAdmin, true, 'Verify that the admin status can be updated without errors');
 
-                        QUnit.start();
+                        // Mock an error from the back-end
+                        var body = {'code': 400, 'msg': 'Bad Request'};
+                        gh.utils.mockRequest('POST', '/api/users/' + user.id + '/admin', 400, {'Content-Type': 'application/json'}, body, function() {
+                            gh.api.userAPI.updateAdminStatus(user.id, true, function(err, data) {
+                                assert.ok(err, 'Verify that the error is handled when the admin status can\'t be successfully updated');
+                                assert.ok(!data, 'Verify that no data returns when the admin status can\'t be successfully updated');
+                                QUnit.start();
+                            });
+                        });
                     });
                 });
             });


### PR DESCRIPTION
It would be useful to have a UI where global admins (and tenant admins) can manage application users.
Things like:
 - Promoting to tenant admin
 - Changing email address
 - Changing display name
etc..

![screen shot 2015-04-16 at 17 05 24](https://cloud.githubusercontent.com/assets/218391/7185490/cfc6312c-e45a-11e4-80bf-af823f8bea1a.png)
