### PR TITLE
Show the `shibbolethId` in the event organisers list and/or auto suggest

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -1358,6 +1358,7 @@ ul.as-selections li.as-original input {
     font-size: 15px;
     padding: 10px 5px;
     text-shadow: none;
+    word-wrap: break-word;
 }
 
 .as-results .as-list {

--- a/shared/gh/js/views/gh.admin-batch-edit-organiser.js
+++ b/shared/gh/js/views/gh.admin-batch-edit-organiser.js
@@ -127,6 +127,11 @@ define(['gh.core', 'jquery-autosuggest'], function(gh) {
                 }
             },
             'retrieveComplete': function(data) {
+                // Append the shibbolethId to the displayName to make it easier to distinguish between users
+                _.each(data.results, function(user) {
+                    var suffix = user.shibbolethId ? ' (' + user.shibbolethId + ')' : '';
+                    user.displayName = user.displayName + suffix;
+                });
                 return data.results;
             },
             'selectionAdded': function(elem, id) {

--- a/shared/gh/js/views/gh.admin-edit-organiser.js
+++ b/shared/gh/js/views/gh.admin-edit-organiser.js
@@ -111,6 +111,11 @@ define(['gh.core', 'jquery.jeditable'], function(gh) {
                     }
                 },
                 'retrieveComplete': function(data) {
+                    // Append the shibbolethId to the displayName to make it easier to distinguish between users
+                    _.each(data.results, function(user) {
+                        var suffix = user.shibbolethId ? ' (' + user.shibbolethId + ')' : '';
+                        user.displayName = user.displayName + suffix;
+                    });
                     return data.results;
                 },
                 'selectionAdded': function(elem, id) {


### PR DESCRIPTION
For example: From
![screen shot 2015-04-17 at 12 06 07](https://cloud.githubusercontent.com/assets/92180/7200951/28fc7fe0-e4fa-11e4-9721-622b75760629.png)
to
![screen shot 2015-04-17 at 12 04 17](https://cloud.githubusercontent.com/assets/92180/7200940/18ea9326-e4fa-11e4-81dc-4445b445d070.png)

Caveat: The `shibbolethId` will not be returned if the current user is not an application administrator. If this should be opened up to third-party users, let me know and I'll make the change in the backend.