### PR TITLE
Improve student UI list scrolling behaviour

### DIFF
--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -140,7 +140,7 @@ select[disabled],
     float: left;
     height: 100%;
     padding: 0;
-    position: fixed;
+    position: relative;
     -webkit-transition: width .3s;
        -moz-transition: width .3s;
          -o-transition: width .3s;
@@ -241,8 +241,6 @@ select[disabled],
 }
 
 #gh-page-container #gh-left-container #gh-modules-container #gh-modules-list {
-    height: 100%;
-    -webkit-overflow-scrolling: touch;
     width: 320px;
 }
 

--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -835,6 +835,7 @@ tbody tr:last-child > td.fc-widget-content {
     border-bottom: 1px solid #DDD;
 }
 
+
 /**********/
 /* CHOSEN */
 /**********/
@@ -1145,6 +1146,7 @@ tbody tr:last-child > td.fc-widget-content {
 .agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week .gh-agenda-view-term-event {
     border-bottom-style: solid;
     border-bottom-width: 1px;
+    overflow: hidden;
     padding: 12px;
 }
 


### PR DESCRIPTION
The scroll bar interferes quite a bit with the main journey of adding items to your calendar, so we should make that better a little bit by eliminating the middle scroll bar if we can.

![my_timetable_mar_26_ _apr_1__2015](https://cloud.githubusercontent.com/assets/117483/6896351/517a6822-d6e2-11e4-9e12-ef7d9d0bf7c6.png)

One idea to do this is here:
https://drive.google.com/open?id=0B2lp5OAL6DPFQk51UDRLZlhpSE0&authuser=0