### PR TITLE
Deleting a series should update the module navigation

### DIFF
--- a/shared/gh/js/views/gh.delete-series.js
+++ b/shared/gh/js/views/gh.delete-series.js
@@ -79,7 +79,7 @@ define(['gh.core', 'gh.constants', 'gh.api.series', 'gh.api.orgunit'], function(
             $('#gh-delete-series-modal').modal('hide');
 
             // Remove the series from the navigation
-            $('.list-group-item[data-id="' + seriesId + '"').remove();
+            $('.list-group-item[data-id="' + seriesId + '"]').remove();
 
             // Remove the series from the state
             removeSeriesFromState();


### PR DESCRIPTION
Currently, when deleting a series the module navigation isn't updated and it looks like the series hasn't been deleted.