### PR TITLE
Filter out duplicates in batch edit

### DIFF
--- a/apps/timetable/admin/ui/js/index.js
+++ b/apps/timetable/admin/ui/js/index.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'gh.constants', 'gh.listview', 'gh.admin-listview', 'gh.admin-batch-edit', 'gh.calendar', 'gh.subheader', 'gh.video', 'clickover', 'jquery.jeditable', 'validator'], function(gh, constants) {
+define(['gh.core', 'gh.constants', 'moment', 'gh.listview', 'gh.admin-listview', 'gh.admin-batch-edit', 'gh.calendar', 'gh.subheader', 'gh.video', 'clickover', 'jquery.jeditable', 'validator'], function(gh, constants, moment) {
 
     // Cache the tripos data
     var triposData = {};
@@ -194,6 +194,13 @@ define(['gh.core', 'gh.constants', 'gh.listview', 'gh.admin-listview', 'gh.admin
         delete data.events;
         // Order the events and split up the out of term events
         data.eventsByTerm = gh.utils.orderEventsByTerm(data.eventsByTerm);
+        // Refactor each start and end date to the same format the UI expects
+        _.each(data.eventsByTerm, function(term) {
+            _.each(term.events, function(ev) {
+                ev.start = gh.utils.convertUnixDatetoISODate(moment(ev.end).utc().format());
+                ev.end = gh.utils.convertUnixDatetoISODate(moment(ev.end).utc().format());
+            });
+        });
         // Render the batch edit template
         gh.utils.renderTemplate($('#gh-batch-edit-template'), {
             'data': {

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -149,20 +149,20 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
         if ($lastEventInTerm.length) {
             eventObj.data.ev = data && data.eventObj ? data.eventObj : {
                 'displayName': $('.gh-jeditable-series-title').text(),
-                'end': moment($($lastEventInTerm.find('.gh-event-date')).attr('data-end')).add(7, 'days').toISOString(),
+                'end': gh.utils.convertUnixDatetoISODate(moment($($lastEventInTerm.find('.gh-event-date')).attr('data-end')).add(7, 'days').utc().format()),
                 'location': defaultLocation,
                 'organisers': defaultOrganisers,
-                'start': moment($($lastEventInTerm.find('.gh-event-date')).attr('data-start')).add(7, 'days').toISOString(),
+                'start': gh.utils.convertUnixDatetoISODate(moment($($lastEventInTerm.find('.gh-event-date')).attr('data-start')).add(7, 'days').utc().format()),
                 'type': gh.config.events.default
             };
         // If no events were previously added to the term, create a default event object
         } else {
             eventObj.data.ev = data && data.eventObj ? data.eventObj : {
                 'displayName': $('.gh-jeditable-series-title').text(),
-                'end': moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 14, 0, 0, 0])).toISOString(),
+                'end': gh.utils.convertUnixDatetoISODate(moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 14, 0, 0, 0])).utc().format()),
                 'location': defaultLocation,
                 'organisers': defaultOrganisers,
-                'start': moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 13, 0, 0, 0])).toISOString(),
+                'start': gh.utils.convertUnixDatetoISODate(moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 13, 0, 0, 0])).utc().format()),
                 'type': gh.config.events.default
             };
         }

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -159,10 +159,10 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
         } else {
             eventObj.data.ev = data && data.eventObj ? data.eventObj : {
                 'displayName': $('.gh-jeditable-series-title').text(),
-                'end': gh.utils.convertUnixDatetoISODate(moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 14, 0, 0, 0])).utc().format()),
+                'end': gh.utils.convertUnixDatetoISODate(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 14, 0, 0, 0]).utc().format()),
                 'location': defaultLocation,
                 'organisers': defaultOrganisers,
-                'start': gh.utils.convertUnixDatetoISODate(moment(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 13, 0, 0, 0])).utc().format()),
+                'start': gh.utils.convertUnixDatetoISODate(moment([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 13, 0, 0, 0]).utc().format()),
                 'type': gh.config.events.default
             };
         }

--- a/shared/gh/js/views/gh.datepicker.js
+++ b/shared/gh/js/views/gh.datepicker.js
@@ -108,8 +108,8 @@ define(['gh.core', 'moment', 'clickover', 'jquery-datepicker'], function(gh, mom
 
         // Return the full dates
         return {
-            'start': startDate,
-            'end': endDate
+            'start': gh.utils.convertUnixDatetoISODate(moment(startDate).utc().format()),
+            'end': gh.utils.convertUnixDatetoISODate(moment(endDate).utc().format())
         };
     };
 


### PR DESCRIPTION
To reproduce: Add a single event to an empty term, go into the batch edit header and add another week.