### PR TITLE
The student UI is still including permissions when retrieving the tripos structure

### DIFF
--- a/apps/timetable/admin/ui/js/index.js
+++ b/apps/timetable/admin/ui/js/index.js
@@ -31,7 +31,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.listview', 'gh.admin-listview',
     var getTriposData = function() {
 
         // Fetch the triposes
-        gh.utils.getTriposStructure(null, function(err, data) {
+        gh.utils.getTriposStructure(null, true, function(err, data) {
             if (err) {
                 return gh.utils.notification('Could not fetch triposes', constants.messaging.default.error, 'error');
             }

--- a/apps/timetable/ui/js/index.js
+++ b/apps/timetable/ui/js/index.js
@@ -188,7 +188,7 @@ define(['gh.core', 'gh.constants', 'gh.subheader', 'gh.calendar', 'gh.student-li
      */
     var fetchTriposData = function(callback) {
         // Fetch the triposes
-        gh.utils.getTriposStructure(null, function(err, data) {
+        gh.utils.getTriposStructure(null, false, function(err, data) {
             if (err) {
                 return gh.utils.notification('Could not fetch triposes', constants.messaging.default.error, 'error');
             }

--- a/shared/gh/js/utils/gh.utils.orgunits.js
+++ b/shared/gh/js/utils/gh.utils.orgunits.js
@@ -88,10 +88,10 @@ define(['exports'], function(exports) {
     /**
      * Return the tripos structure
      *
-     * @param  {Number}      [appId]              The application to retrieve the tripos structure for
-     * @param  {Function}    callback             Standard callback function
-     * @param  {Object}      callback.err         Error object containing the error code and error message
-     * @param  {Object}      callback.response    The tripos structure
+     * @param  {Number}     [appId]               The application to retrieve the tripos structure for
+     * @param  {Boolean}    includePermissions    Whether the permissions should be included or not
+     * @param  {Object}     callback.err          Error object containing the error code and error message
+     * @param  {Object}     callback.response     The tripos structure
      *
      * * The returned tripos structure will be something in the lines of:
      * *
@@ -129,9 +129,11 @@ define(['exports'], function(exports) {
      * *     ]
      * * }
      */
-    var getTriposStructure = exports.getTriposStructure = function(appId, callback) {
+    var getTriposStructure = exports.getTriposStructure = function(appId, includePermissions, callback) {
         if (!_.isFunction(callback)) {
             throw new Error('An invalid value for callback was provided');
+        } else if (!_.isBoolean(includePermissions)) {
+            throw new Error('An invalid value for includePermissions was provided');
         } else if (appId && !_.isNumber(appId)) {
             throw new Error('An invalid value for appId was provided');
         }
@@ -141,7 +143,7 @@ define(['exports'], function(exports) {
             appId = core.data.me && core.data.me.AppId ? core.data.me.AppId : null;
         }
 
-        require('gh.api.orgunit').getOrgUnits(appId, false, true, null, ['course', 'subject', 'part'], function(err, data) {
+        require('gh.api.orgunit').getOrgUnits(appId, false, includePermissions, null, ['course', 'subject', 'part'], function(err, data) {
             if (err) {
                 return callback(err);
             }

--- a/shared/gh/js/views/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/gh.admin-batch-edit.js
@@ -513,7 +513,7 @@ define(['gh.core', 'gh.constants', 'moment', 'gh.calendar', 'gh.admin-event-type
     var setUpPreviewCalendar = function(callback) {
         // Fetch the triposes
         if (!triposData) {
-            gh.utils.getTriposStructure(null, function(err, data) {
+            gh.utils.getTriposStructure(null, true, function(err, data) {
                 if (err) {
                     return gh.utils.notification('Could not fetch triposes', constants.messaging.default.error, 'error');
                 }

--- a/shared/gh/js/views/gh.borrow-series.js
+++ b/shared/gh/js/views/gh.borrow-series.js
@@ -102,7 +102,7 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit'], function(gh, constants, or
         var partId = $(this).closest('#gh-modules-list-container').data('partid');
 
         // Fetch the triposes
-        gh.utils.getTriposStructure(null, function(err, _triposData) {
+        gh.utils.getTriposStructure(null, true, function(err, _triposData) {
             // Cache the triposdata for use in the other picker
             triposData = _triposData;
 

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -946,7 +946,7 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
 
         // Retrieve the tripos structure for the test app
         var testApp = testAPI.getTestApp();
-        gh.utils.getTriposStructure(testApp.id, function(err, data) {
+        gh.utils.getTriposStructure(testApp.id, false, function(err, data) {
             assert.ok(!err);
 
             // Find an organisational unit that has parents
@@ -994,7 +994,7 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
         var testApp = testAPI.getTestApp();
 
         // Retrieve and cache the tripos structure
-        gh.utils.getTriposStructure(testApp.id, function(err, data) {
+        gh.utils.getTriposStructure(testApp.id, false, function(err, data) {
             assert.ok(!err);
 
             // Retrieve the parts for the test application
@@ -1085,7 +1085,7 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
 
         // Retrieve the tripos structure for the test app
         var testApp = testAPI.getTestApp();
-        gh.utils.getTriposStructure(testApp.id, function(err, data) {
+        gh.utils.getTriposStructure(testApp.id, false, function(err, data) {
             assert.ok(!err);
 
             // Verify that all the parts that have a parent are decorated with their parent
@@ -1100,32 +1100,42 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
 
     // Test the 'getTriposStructure' functionality
     QUnit.asyncTest('getTriposStructure', function(assert) {
-        expect(8);
+        expect(10);
 
         // Verify that an error is thrown when an invalid value for app id was provided
         assert.throws(function() {
-            gh.utils.getTriposStructure('invalid_app_id', function() {});
+            gh.utils.getTriposStructure('invalid_app_id', false, function() {});
         }, 'Verify that an error is thrown when an invalid value for app id was provided');
+
+        // Verify that an error is thrown when no value for includePermissions was provided
+        assert.throws(function() {
+            gh.utils.getTriposStructure(null, null, function() {});
+        }, 'Verify that an error is thrown when an invalid value for includePermissions was provided');
+
+        // Verify that an error is thrown when no value for includePermissions was provided
+        assert.throws(function() {
+            gh.utils.getTriposStructure(null, 'invalid_value', function() {});
+        }, 'Verify that an error is thrown when an invalid value for includePermissions was provided');
 
         // Verify that an error is thrown when no callback was provided
         assert.throws(function() {
-            gh.utils.getTriposStructure(null);
+            gh.utils.getTriposStructure(null, false);
         }, 'Verify that an error is thrown when no callback was provided');
 
         // Verify that an error is thrown when an invalid callback was provided
         assert.throws(function() {
-            gh.utils.getTriposStructure(null, 'invalid_callback');
+            gh.utils.getTriposStructure(null, false, 'invalid_callback');
         }, 'Verify that an error is thrown when an invalid callback was provided');
 
         // Retrieve the tripos structure for the test application
         var testApp = testAPI.getTestApp();
-        gh.utils.getTriposStructure(testApp.id, function(err, data) {
+        gh.utils.getTriposStructure(testApp.id, false, function(err, data) {
             assert.ok(!err, 'Verify that the tripos structure can be requested without errors');
             assert.ok(data, 'Verify that the tripos structure is returned');
 
             // Retrieve the tripos structure when the application ID was set in the `me` object
             gh.data.me.AppId = testApp.id;
-            gh.utils.getTriposStructure(null, function(err, data) {
+            gh.utils.getTriposStructure(null, false, function(err, data) {
                 assert.ok(!err, 'Verify that the tripos structure can be requested without errors');
                 assert.ok(data, 'Verify that the tripos structure is returned');
 
@@ -1135,7 +1145,7 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
                 }
 
                 // Retrieve the tripos structure when no application ID was set
-                gh.utils.getTriposStructure(null, function(err, data) {
+                gh.utils.getTriposStructure(null, false, function(err, data) {
                     assert.ok(err, 'Verify that an error is thrown when no application ID is set');
                     QUnit.start();
                 });


### PR DESCRIPTION
The `getTriposStructure` utility is still blindly setting `includePermissions` to `true` when doing the `getOrgUnits` call. AFAIK, this is unnecessary in the Student UI. As that request will be one of the hot-paths of the application it would be good if that could be set to `false`.