### PR TITLE
Login-modal should get it's own handling, split out from index.js

### DIFF
--- a/apps/timetable/ui/js/index.js
+++ b/apps/timetable/ui/js/index.js
@@ -110,30 +110,6 @@ define(['gh.core', 'gh.constants', 'gh.subheader', 'gh.calendar', 'gh.student-li
         }
     };
 
-    /**
-     * Render the login modal dialog used to prompt anonymous users to sign in
-     *
-     * @private
-     */
-    var renderLoginModal = function() {
-        gh.utils.renderTemplate('login-modal', {
-            'data': {
-                'gh': gh,
-                'isGlobalAdminUI': false
-            }
-        }, $('#gh-modal'), function() {
-            // Bind the validator to the login form
-            $('.gh-signin-form').validator({
-                'disable': false
-            }).on('submit', doLogin);
-        });
-
-        // Track an event when the login modal is shown
-        $('#gh-modal-login').on('shown.bs.modal', function () {
-            gh.utils.trackEvent(['Navigation', 'Authentication modal triggered']);
-        });
-    };
-
 
     /////////////////
     //  UTILITIES  //
@@ -238,7 +214,6 @@ define(['gh.core', 'gh.constants', 'gh.subheader', 'gh.calendar', 'gh.student-li
         fetchTriposData(function() {
             setUpHeader();
             setUpCalendar();
-            renderLoginModal();
         });
     };
 

--- a/shared/gh/js/gh.bootstrap.js
+++ b/shared/gh/js/gh.bootstrap.js
@@ -85,6 +85,7 @@ requirejs.config({
         'gh.delete-module': 'gh/js/views/gh.delete-module',
         'gh.delete-series': 'gh/js/views/gh.delete-series',
         'gh.listview': 'gh/js/views/gh.listview',
+        'gh.login-modal': 'gh/js/views/gh.login-modal',
         'gh.new-module': 'gh/js/views/gh.new-module',
         'gh.new-series': 'gh/js/views/gh.new-series',
         'gh.rename-module': 'gh/js/views/gh.rename-module',

--- a/shared/gh/js/views/gh.login-modal.js
+++ b/shared/gh/js/views/gh.login-modal.js
@@ -15,6 +15,9 @@
 
 define(['gh.core'], function(gh) {
 
+    // The trigger that invoked the modal window
+    var $trigger = null;
+
 
     //////////////////////
     //  AUTHENTICATION  //
@@ -67,28 +70,36 @@ define(['gh.core'], function(gh) {
             }
         }, $('#gh-modal'), function() {
 
-            // Add logic once the modal is shown
-            $('#gh-modal-login').on('shown.bs.modal', function() {
-
-                // Track an event when the login modal is shown
-                gh.utils.trackEvent(['Navigation', 'Authentication modal triggered']);
-
-                // Bind the validator to the login form
-                $('.modal-body .gh-signin-form').validator({
-                    'disable': false
-                }).on('submit', doLogin);
-            });
-
-            // Put the focus back on the trigger on hide
-            $('#gh-modal-login').on('hidden.bs.modal', function() {
-                if(msg && msg.data && msg.data.trigger) {
-                    $(msg.data.trigger).focus();
-                }
-            });
+            // Cache the trigger
+            if(msg && msg.data && msg.data.trigger) {
+                $trigger = $(msg.data.trigger);
+            }
 
             // Show the login modal
             $('#gh-modal-login').modal();
         });
+    };
+
+    /**
+     * Add logic when the modal is shown
+     *
+     * @private
+     */
+    var onModalShown = function() {
+        // Track an event when the login modal is shown
+        gh.utils.trackEvent(['Navigation', 'Authentication modal triggered']);
+
+        // Bind the validator to the login form
+        $('body').on('submit', '#gh-modal-login .gh-signin-form', doLogin).validator({'disable': false});
+    };
+
+    /**
+     * Focus the trigger when the modal is hidden
+     *
+     * @private
+     */
+    var onModalHidden = function() {
+        $trigger.focus();
     };
 
 
@@ -102,7 +113,12 @@ define(['gh.core'], function(gh) {
      * @private
      */
     var addBinding = function() {
+        // Setup and show the modal
         $(document).on('gh.login-modal.show', setupAndShowModal);
+        // On modal hidden
+        $('body').on('hidden.bs.modal', '#gh-modal-login', onModalHidden);
+        // On modal shown
+        $('body').on('shown.bs.modal', '#gh-modal-login', onModalShown);
     };
 
     addBinding();

--- a/shared/gh/js/views/gh.login-modal.js
+++ b/shared/gh/js/views/gh.login-modal.js
@@ -53,9 +53,11 @@ define(['gh.core'], function(gh) {
     /**
      * Setup and show the login modal
      *
+     * @param  {Object}    evt    The dispatched jQuery event
+     * @param  {Object}    msg    The event message
      * @private
      */
-    var setupAndShowModal = function() {
+    var setupAndShowModal = function(evt, msg) {
 
         // Render the login modal template
         gh.utils.renderTemplate('login-modal', {
@@ -66,7 +68,7 @@ define(['gh.core'], function(gh) {
         }, $('#gh-modal'), function() {
 
             // Add logic once the modal is shown
-            $('#gh-modal-login').on('shown.bs.modal', function () {
+            $('#gh-modal-login').on('shown.bs.modal', function() {
 
                 // Track an event when the login modal is shown
                 gh.utils.trackEvent(['Navigation', 'Authentication modal triggered']);
@@ -75,6 +77,13 @@ define(['gh.core'], function(gh) {
                 $('.modal-body .gh-signin-form').validator({
                     'disable': false
                 }).on('submit', doLogin);
+            });
+
+            // Put the focus back on the trigger on hide
+            $('#gh-modal-login').on('hidden.bs.modal', function() {
+                if(msg && msg.data && msg.data.trigger) {
+                    $(msg.data.trigger).focus();
+                }
             });
 
             // Show the login modal

--- a/shared/gh/js/views/gh.login-modal.js
+++ b/shared/gh/js/views/gh.login-modal.js
@@ -1,0 +1,100 @@
+/*!
+ * Copyright 2015 Digital Services, University of Cambridge Licensed
+ * under the Educational Community License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *     http://opensource.org/licenses/ECL-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+define(['gh.core'], function(gh) {
+
+
+    //////////////////////
+    //  AUTHENTICATION  //
+    //////////////////////
+
+    /**
+     * Log in using the local authentication strategy
+     *
+     * @param  {Event}    ev    The jQuery event
+     * @private
+     */
+    var doLogin = function(ev) {
+        // Log in to the system if the form is valid and local authentication is enabled.
+        // If Shibboleth is required the native form behaviour will be used and no extra
+        // handling is required
+        if (!ev.isDefaultPrevented() && gh.config.enableLocalAuth && !gh.config.enableShibbolethAuth) {
+            // Collect and submit the form data
+            var formValues = _.object(_.map($(this).serializeArray(), _.values));
+            gh.api.authenticationAPI.login(formValues.username, formValues.password, function(err) {
+                if (err) {
+                    return gh.utils.notification('Could not sign you in', 'Please check that you are entering a correct username & password', 'error');
+                }
+                window.location.reload();
+            });
+
+            // Avoid default form submit behaviour
+            return false;
+        }
+    };
+
+
+    /////////////
+    //  MODAL  //
+    /////////////
+
+    /**
+     * Setup and show the login modal
+     *
+     * @private
+     */
+    var setupAndShowModal = function() {
+
+        // Render the login modal template
+        gh.utils.renderTemplate('login-modal', {
+            'data': {
+                'gh': gh,
+                'isGlobalAdminUI': false
+            }
+        }, $('#gh-modal'), function() {
+
+            // Add logic once the modal is shown
+            $('#gh-modal-login').on('shown.bs.modal', function () {
+
+                // Track an event when the login modal is shown
+                gh.utils.trackEvent(['Navigation', 'Authentication modal triggered']);
+
+                // Bind the validator to the login form
+                $('.modal-body .gh-signin-form').validator({
+                    'disable': false
+                }).on('submit', doLogin);
+            });
+
+            // Show the login modal
+            $('#gh-modal-login').modal();
+        });
+    };
+
+
+    ///////////////
+    //  BINDING  //
+    ///////////////
+
+    /**
+     * Add handlers for the login modal
+     *
+     * @private
+     */
+    var addBinding = function() {
+        $(document).on('gh.login-modal.show', setupAndShowModal);
+    };
+
+    addBinding();
+});

--- a/shared/gh/js/views/gh.student-listview.js
+++ b/shared/gh/js/views/gh.student-listview.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core', 'gh.constants', 'gh.series-info', 'gh.series-borrowed-popover', 'gh.series-borrowed-published-popover', 'clickover'], function(gh, constants) {
+define(['gh.core', 'gh.constants', 'gh.login-modal', 'gh.series-info', 'gh.series-borrowed-popover', 'gh.series-borrowed-published-popover', 'clickover'], function(gh, constants) {
 
     var modules = null;
 
@@ -29,7 +29,7 @@ define(['gh.core', 'gh.constants', 'gh.series-info', 'gh.series-borrowed-popover
      */
     var addAllToCalendar = function() {
         if (gh.data.me.anon) {
-            return $('#gh-modal-login').modal();
+            return $(document).trigger('gh.login-modal.show');
         }
 
         var $list = $(this).closest('li');
@@ -84,7 +84,7 @@ define(['gh.core', 'gh.constants', 'gh.series-info', 'gh.series-borrowed-popover
      */
     var removeAllFromCalendar = function() {
         if (gh.data.me.anon) {
-            return $('#gh-modal-login').modal();
+            return $(document).trigger('gh.login-modal.show');
         }
 
         var $list = $(this).closest('li');
@@ -139,7 +139,7 @@ define(['gh.core', 'gh.constants', 'gh.series-info', 'gh.series-borrowed-popover
      */
     var addToCalendar = function() {
         if (gh.data.me.anon) {
-            return $('#gh-modal-login').modal();
+            return $(document).trigger('gh.login-modal.show');
         }
 
         var $this = $(this);
@@ -209,7 +209,7 @@ define(['gh.core', 'gh.constants', 'gh.series-info', 'gh.series-borrowed-popover
      */
     var removeFromCalendar = function() {
         if (gh.data.me.anon) {
-            return $('#gh-modal-login').modal();
+            return $(document).trigger('gh.login-modal.show');
         }
 
         var $this = $(this);

--- a/shared/gh/js/views/gh.student-listview.js
+++ b/shared/gh/js/views/gh.student-listview.js
@@ -29,7 +29,7 @@ define(['gh.core', 'gh.constants', 'gh.login-modal', 'gh.series-info', 'gh.serie
      */
     var addAllToCalendar = function() {
         if (gh.data.me.anon) {
-            return $(document).trigger('gh.login-modal.show');
+            return $(document).trigger('gh.login-modal.show', {'data': {'trigger': $(this)}});
         }
 
         var $list = $(this).closest('li');
@@ -84,7 +84,7 @@ define(['gh.core', 'gh.constants', 'gh.login-modal', 'gh.series-info', 'gh.serie
      */
     var removeAllFromCalendar = function() {
         if (gh.data.me.anon) {
-            return $(document).trigger('gh.login-modal.show');
+            return $(document).trigger('gh.login-modal.show', {'data': {'trigger': $(this)}});
         }
 
         var $list = $(this).closest('li');
@@ -139,7 +139,7 @@ define(['gh.core', 'gh.constants', 'gh.login-modal', 'gh.series-info', 'gh.serie
      */
     var addToCalendar = function() {
         if (gh.data.me.anon) {
-            return $(document).trigger('gh.login-modal.show');
+            return $(document).trigger('gh.login-modal.show', {'data': {'trigger': $(this)}});
         }
 
         var $this = $(this);
@@ -209,7 +209,7 @@ define(['gh.core', 'gh.constants', 'gh.login-modal', 'gh.series-info', 'gh.serie
      */
     var removeFromCalendar = function() {
         if (gh.data.me.anon) {
-            return $(document).trigger('gh.login-modal.show');
+            return $(document).trigger('gh.login-modal.show', {'data': {'trigger': $(this)}});
         }
 
         var $this = $(this);


### PR DESCRIPTION
The current implementation of the login-modal isn't up to par with the rest of the modals.

It should only be rendered and shown when an anonymous user triggers an action that can only be done once signed in.