### PR TITLE
The navigation bar should always take 100% height

### DIFF
--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -127,8 +127,8 @@ select[disabled],
 /**********/
 
 #gh-main {
-    margin-bottom: 30px;
     overflow: hidden;
+    padding-bottom: 30px;
 }
 
 .gh-academic-year-select {
@@ -199,7 +199,7 @@ select[disabled],
 
 #gh-page-container #gh-left-container #gh-navigation-container,
 #gh-page-container #gh-left-container #gh-modules-container {
-    height: calc(100% + 1px);
+    min-height: 100%;
     padding-bottom: 45px;
     padding-top: 215px;
 }
@@ -303,7 +303,10 @@ select[disabled],
 }
 
 #gh-page-container #gh-right-container {
-    height: 100%;
+    -webkit-background-clip: content-box;
+       -moz-background-clip: content-box;
+            background-clip: content-box;
+    min-height: 100%;
     min-width: 992px;
     padding-left: 320px;
     -webkit-transition: padding-left .3s;
@@ -348,6 +351,7 @@ select[disabled],
 
 .gh-collapsed #gh-page-container #gh-left-container {
     width: 50px !important;
+    position: fixed;
 }
 
 .gh-collapsed #gh-page-container #gh-right-container {
@@ -360,7 +364,6 @@ select[disabled],
 }
 
 .gh-collapsed #gh-page-container #gh-left-container #gh-modules-container #gh-modules-list-container {
-    height: 100%;
     opacity: 0;
 }
 

--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -350,8 +350,8 @@ select[disabled],
 /* Content containers */
 
 .gh-collapsed #gh-page-container #gh-left-container {
-    width: 50px !important;
     position: fixed;
+    width: 50px !important;
 }
 
 .gh-collapsed #gh-page-container #gh-right-container {

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -92,16 +92,18 @@ a,
 /* LAYOUT */
 /**********/
 
+#gh-page-container,
+#gh-page-container #gh-left-container #gh-navigation-container,
+#gh-page-container #gh-left-container #gh-modules-container {
+    background-color: #171717;
+}
+
 #gh-page-container #gh-left-container #gh-result-summary {
     background-color: #127077;
     border-bottom-color: #171717;
 }
 
-#gh-page-container #gh-left-container,
-#gh-page-container #gh-left-container #gh-meta-container {
-    background-color: #171717;
-}
-
+#gh-page-container #gh-right-container,
 #gh-page-container #gh-header {
     background-color: #FFF;
 }


### PR DESCRIPTION
Currently the left-hand side navigation bar takes 100% of the page height. That doesn't suffice when the main element is higher than that though. The side navigation should always have a minimum height of 100% and if the main element is higher, the min-height should be set to the main element's height.

We might be able to achieve this just by moving around background colours on the containing elements.