### PR TITLE
Series info modal occasionally throws an error

### DIFF
--- a/shared/gh/js/views/gh.agenda-view.js
+++ b/shared/gh/js/views/gh.agenda-view.js
@@ -18,7 +18,7 @@ define(['gh.core'], function(gh) {
     // Get the configuration
     var config = require('gh.core').config;
     // Get the correct terms associated to the current application
-    var terms = config.terms[config.academicYear];
+    var terms = _.map(config.terms[config.academicYear], _.clone);
 
 
     ///////////////

--- a/shared/gh/js/views/gh.series-info.js
+++ b/shared/gh/js/views/gh.series-info.js
@@ -131,7 +131,9 @@ define(['gh.core', 'gh.constants', 'moment'], function(gh, constants, moment) {
     var groupSeriesEventsByTerms = function(events) {
 
         // Cache the terms
-        var _terms = _.map(gh.config.terms[gh.config.academicYear], function(term) { return _.clone(term); });
+        var _terms = _.map(gh.config.terms[gh.config.academicYear], function(term) {
+            return _.extend({}, term);
+        });
 
         // Add the events to the corresponding term
         _.each(events, function(evt) {


### PR DESCRIPTION
The series info modal occasionally throws an error when opening the modal:

```javascript
Uncaught TypeError: term.events.push is not a function
    (anonymous function) @ gh.series-info.js:149
    forEach @ lodash.js:3297
    (anonymous function) @ gh.series-info.js:140
    forEach @ lodash.js:3297
    groupSeriesEventsByTerms @ gh.series-info.js:137
    retrieveSeries @ gh.series-info.js:84
    (anonymous function) @ gh.series-info.js:71
    $.ajax.success @ gh.api.series.js:327
    jQuery.Callbacks.fire @ require-jquery.js:5114
    jQuery.Callbacks.self.fireWith @ require-jquery.js:5226
    done @ require-jquery.js:10279
    jQuery.ajaxTransport.send.callback @ require-jquery.js:10620
```