### PR TITLE
Fix Moment.js deprecation warning

### DIFF
--- a/shared/gh/js/views/gh.agenda-view.js
+++ b/shared/gh/js/views/gh.agenda-view.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core'], function(gh) {
+define(['gh.core', 'moment'], function(gh, moment) {
 
     // Get the configuration
     var config = require('gh.core').config;
@@ -38,6 +38,7 @@ define(['gh.core'], function(gh) {
         // Render the agenda view
         gh.utils.renderTemplate('agenda-view', {
             'data': {
+                'moment': moment,
                 'openedTerms': require('gh.core').utils.localDataStorage().get('myagenda'),
                 'terms': terms,
                 'utils': gh.utils

--- a/shared/gh/partials/agenda-view.html
+++ b/shared/gh/partials/agenda-view.html
@@ -9,7 +9,7 @@
      * @return {Boolean}              Return `true` if the dates match
      * @private
      */
-    var isADifferentDay = function(_prevDate, currDate) {
+    var isADifferentDay = function(_prevDate, currDate, moment) {
         return moment(_prevDate).format('YYYYMMDD') === moment(currDate).format('YYYYMMDD');
     };
 
@@ -19,7 +19,7 @@
      * @return {Number}    The current academic week number
      * @private
      */
-    var getCurrentAcademicWeekNumber = function() {
+    var getCurrentAcademicWeekNumber = function(moment) {
         return data.utils.getAcademicWeekNumber(data.utils.convertISODatetoUnixDate((moment(new Date()).format('YYYY-MM-DD'))), true);
     };
 
@@ -30,7 +30,7 @@
      * @return {Boolean}            Returns `true` if the provided date is today
      * @private
      */
-    var isToday = function(date) {
+    var isToday = function(date, moment) {
         return moment(date).format('YYYYMMDD') === moment(new Date()).format('YYYYMMDD');
     }
 %>
@@ -48,18 +48,18 @@
             <% _.each(term.events, function(week, weekIndex) { %>
                 <% prevDate = null %>
                 <div class="gh-agenda-view-term-week">
-                    <h3>Week <%- parseInt(weekIndex, 10) + 1 %><% if (parseInt(weekIndex, 10) + 1 === getCurrentAcademicWeekNumber() && currentTerm.name === term.name) { %> <span>- this week</span><% } %></h3>
+                    <h3>Week <%- parseInt(weekIndex, 10) + 1 %><% if (parseInt(weekIndex, 10) + 1 === getCurrentAcademicWeekNumber(data.moment) && currentTerm.name === term.name) { %> <span>- this week</span><% } %></h3>
                     <% if (!week.length) { %>
                         <div class="gh-agenda-view-no-events">You have no events scheduled in week <%- parseInt(weekIndex, 10) + 1 %> of <%- term.label %></div>
                     <% } %>
                     <% _.each(week, function(event, eventIndex) { %>
-                        <% var prevSameDate = isADifferentDay(prevDate, event.start) %>
+                        <% var prevSameDate = isADifferentDay(prevDate, event.start, data.moment) %>
                         <% if (!prevSameDate) { %>
                             <!-- If the dates don't match each other and the event index is not 0, close the last one -->
                             <% if (eventIndex) { %>
                                 </div>
                             <% } %>
-                            <div class="gh-agenda-view-term-event <% if (isToday(event.start)) { %> gh-agenda-view-today<% } %>">
+                            <div class="gh-agenda-view-term-event <% if (isToday(event.start, data.moment)) { %> gh-agenda-view-today<% } %>">
                                 <div class="gh-calendar-icon-container">
                                     <span class="gh-event-calendar-icon gh-event-calendar-icon-xl">
                                         <span class="month"><%- data.utils.dateDisplay(event.start).monthName() %></span>


### PR DESCRIPTION
When switching to agenda view, the following warning pops up: `Deprecation warning: Accessing Moment through the global scope is deprecated, and will be removed in an upcoming release.`