### PR TITLE
(Sign-In & Sign Out) as a timetable Administrator is highly Inconsistent in Internet explorer Browser

### DIFF
--- a/shared/gh/js/controllers/gh.api.user.js
+++ b/shared/gh/js/controllers/gh.api.user.js
@@ -30,6 +30,7 @@ define(['exports'], function(exports) {
 
         $.ajax({
             'url': '/api/me',
+            'cache': false,
             'type': 'GET',
             'success': function(data) {
                 return callback(null, data);


### PR DESCRIPTION
sign In to Timetable Administration app using Internet Explorer Browser(verified against version 11,10,9,8) doesn't allow user to log-in, for other Browser it works fine(Firefox, Chrome,Safari).

This is blocker ,stopping to carry further testing in IE Browser

Note: I have noticed that user email address is case sensitive , when I tried (Admin2@example.com), authentication failed but when I tried (admin2@example.com) it worked. Please ignore this note if it is requirement. 

Attached Screenshot for reference 

![time table admin-login](https://cloud.githubusercontent.com/assets/12182828/7563084/b51a3208-f7d1-11e4-885e-1bdea0fd4280.png)
