### PR TITLE
Buttons don't seem to be vertically-aligned centred in IE11

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -687,11 +687,11 @@ tbody tr:last-child > td.fc-widget-content {
 }
 
 .list-group .list-group-item .gh-list-action .btn-link {
-    height: 100%;
-    padding: 13px 16px;
+    height: 44px;
+    margin-top: -22px;
+    padding: 0 16px;
     position: absolute;
     right: 0;
-    top: 0;
 }
 
 .list-group .list-group-item .gh-list-action .btn-link:disabled {


### PR DESCRIPTION
![screen shot 2015-05-12 at 14 27 16](https://cloud.githubusercontent.com/assets/2194396/7588202/804506c4-f8b3-11e4-9f80-fbc1a737b558.png)