### PR TITLE
Disable unpublished parts in picker

### DIFF
--- a/shared/gh/js/views/gh.subheader.js
+++ b/shared/gh/js/views/gh.subheader.js
@@ -109,10 +109,7 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.admin.visibility', 'cho
 
         // Get the parts associated to the selected tripos
         var parts = _.filter(triposData.parts, function(part) {
-            // Only add the parts that are published for the normal users
-            if (part.published || (!part.published && part.canManage)) {
-                return parseInt(data.selected, 10) === part.ParentId;
-            }
+            return parseInt(data.selected, 10) === part.ParentId;
         });
 
         // Render the results in the part picker

--- a/shared/gh/partials/subheader-part.html
+++ b/shared/gh/partials/subheader-part.html
@@ -1,8 +1,8 @@
 <option value=""></option>
 <%_.each(data.parts, function(part) { %>
-    <% if (data.excludePart !== part.id) { %>
-        <option value="<%- part.id %>"><%- part.displayName %><% if(!part.published) { %> - Draft<% } %></option>
-    <% } else { %>
+    <% if(data.excludePart === part.id || (!part.canManage && !part.published)) { %>
         <option value="" disabled><%- part.displayName %><% if(!part.published) { %> - Draft (N/A)<% } %></option>
+    <% } else { %>
+        <option value="<%- part.id %>"><%- part.displayName %><% if(!part.published) { %> - Draft<% } %></option>
     <% } %>
 <% }); %>


### PR DESCRIPTION
Unpublished parts should be visible, but disabled. Showing an empty list causes confusion amongst the users.

![screen shot 2015-05-12 at 15 43 07](https://cloud.githubusercontent.com/assets/2194396/7589920/a02e67aa-f8bd-11e4-9baf-79be4f683dcc.png)
