### PR TITLE
Quick Look Video on How to use the new timetable in Timetable Administration doesn't display content ....

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared/gh/files/video"]
-	path = shared/gh/files/video
-	url = https://github.com/CUL-DigitalServices/grasshopper-video.git

--- a/shared/gh/js/constants/gh.constants.js
+++ b/shared/gh/js/constants/gh.constants.js
@@ -59,6 +59,7 @@ define(['exports'], function(exports) {
         'admin-modules': '/shared/gh/partials/admin-modules.html',
         'admin-subheader-pickers': '/shared/gh/partials/admin-subheader-pickers.html',
         'admin-tripos-help': '/shared/gh/partials/admin-tripos-help.html',
+        'admin-video': '/shared/gh/partials/admin-video.html',
         'agenda-view': '/shared/gh/partials/agenda-view.html',
         'borrow-series-modal': '/shared/gh/partials/borrow-series-modal.html',
         'calendar': '/shared/gh/partials/calendar.html',

--- a/shared/gh/js/views/tenant-admin/gh.video.js
+++ b/shared/gh/js/views/tenant-admin/gh.video.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define([], function() {
+define(['gh.core'], function(gh) {
 
 
     /////////////////
@@ -21,26 +21,29 @@ define([], function() {
     /////////////////
 
     /**
-     * Play the video
+     * Render and play the video
      *
      * @private
      */
-    var playVideo = function() {
-        $('.gh-video').addClass('isPlaying');
-        var $video = $('#gh-video').get(0);
-        $video.load();
-        $video.play();
+    var renderAndPlayVideo = function() {
+        var youtubeId = 'M7lc1UVf-VE';
+        var videoURL = '//www.youtube.com/embed/' + youtubeId + '?enablejsapi=1&autoplay=1&hl=en-gb&modestbranding=1&rel=0&showinfo=0&color=white&theme=light';
+
+        gh.utils.renderTemplate('admin-video', {
+            'videoURL': videoURL
+        }, $('#gh-video-container'), function() {
+            $('.gh-video').addClass('isPlaying');
+        });
     };
 
     /**
-     * Stop the video
+     * Stop the video by removing it from the page
      *
      * @private
      */
     var stopVideo = function() {
         $('.gh-video').removeClass('isPlaying');
-        var $video = $('#gh-video').get(0);
-        $video.pause();
+        $('#gh-video-container').empty();
     };
 
 
@@ -54,7 +57,7 @@ define([], function() {
      * @private
      */
     var addBinding = function() {
-        $(document).on('gh.video.play', playVideo);
+        $(document).on('gh.video.play', renderAndPlayVideo);
         $(document).on('gh.video.stop', stopVideo);
     };
 

--- a/shared/gh/js/views/tenant-admin/gh.video.js
+++ b/shared/gh/js/views/tenant-admin/gh.video.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-define(['gh.core'], function(gh) {
+define(['gh.core', 'gh.constants'], function(gh, constants) {
 
 
     /////////////////
@@ -26,7 +26,7 @@ define(['gh.core'], function(gh) {
      * @private
      */
     var renderAndPlayVideo = function() {
-        var youtubeId = gh.config.video.adminhowto;
+        var youtubeId = constants.video.adminhowto;
         var videoURL = '//www.youtube.com/embed/' + youtubeId + '?enablejsapi=1&autoplay=1&hl=en-gb&modestbranding=1&rel=0&showinfo=0&color=white&theme=light';
 
         gh.utils.renderTemplate('admin-video', {

--- a/shared/gh/partials/admin-video.html
+++ b/shared/gh/partials/admin-video.html
@@ -1,0 +1,1 @@
+<iframe src="${videoURL}" width="738" height="415" frameborder="0" allowfullscreen></iframe>

--- a/shared/gh/partials/editable-parts.html
+++ b/shared/gh/partials/editable-parts.html
@@ -1,10 +1,6 @@
 <div id="gh-main-tripos">
     <div class="gh-video" <% if (data.hideVideo) {%>style="display: none;"<% } %>>
-        <video id="gh-video" controls>
-            <source src="/shared/gh/files/video/adminhowto.mp4" type="video/mp4"/>
-            <source src="/shared/gh/files/video/adminhowto.webm" type="video/webm"/>
-            <source src="/shared/gh/files/video/adminhowto.ogv" type="video/ogg"/>
-        </video>
+        <div id="gh-video-container"><!-- --></div>
         <button class="btn gh-hide-video">
             <span aria-hidden="true">×</span>
             <span class="sr-only">Close</span>


### PR DESCRIPTION
Quick Look Video on "How to use the new timetable" in Timetable Administration app doesn't display content in Browsers 
-Internet Explorer-Version (11,10,9,8)
-Firefox- 25
-Safari-5.1.7

Operation System-Windows 7 Professional 64/32 bit

It work fine in Chrome browser.