### PR TITLE
Editting Module Event time- (Day and time) dropdown options doesnt dislay the time on interface

### DIFF
--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -52,6 +52,7 @@ h3 {
 
 select.form-control {
     height: 45px;
+    padding: 0 0 0 2px;
 }
 
 label {


### PR DESCRIPTION
-Editing Module Event - (Day and time) drop down buttons covering the day and time view on interface, this happens in  Front Motion Firefox browser(25 v), OS Windows 7 Professional.(not sure whether this browser is supported or not)

-In Chrome browser(42.0 v) time is not displayed in fields, and day field length should be increased so that when day is selected it should display full text of the day 

-In firefox browser(37.0 v) time is not displayed in fields, and day field length should be increased so that when day is selected it should display full text of the day 

-Attached Screenshot for reference

![chrome-edit event day and time](https://cloud.githubusercontent.com/assets/12182828/7568530/38f3c62e-f7fb-11e4-9664-855bab9ffc12.JPG)

![edit event time-firefox](https://cloud.githubusercontent.com/assets/12182828/7568531/3910de58-f7fb-11e4-8459-683d31900d88.JPG)



