### PR TITLE
Empty timetable icon not aligned properly in IE

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -528,8 +528,9 @@ tbody tr:last-child > td.fc-widget-content {
 /**************/
 
 #gh-empty {
-    margin-bottom: 30px;
+    margin-bottom: 70px;
     margin-left: -320px;
+    position: relative;
     text-align: center;
 }
 
@@ -541,6 +542,7 @@ tbody tr:last-child > td.fc-widget-content {
 }
 
 .gh-empty-icons .fa {
+    left: 50%;
     position: absolute;
 }
 


### PR DESCRIPTION
![screen shot 2015-05-19 at 14 44 51](https://cloud.githubusercontent.com/assets/2194396/7704340/b052188e-fe35-11e4-9826-6dd4eb47d125.png)
