### PR TITLE
Exclude the favicons from the optimized build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -255,6 +255,7 @@ module.exports = function(grunt) {
                         'files': _hashFiles({
                             'directories': [
                                 '<%= target %>/optimized/shared/gh/**',
+                                '!<%= target %>/optimized/shared/gh/img/favicon',
                                 '<%= target %>/optimized/apps'
                             ],
                             'excludeExts': ['html']

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-ghost": "latest",
     "grunt-qunit-istanbul": "0.4.5",
     "grunt-text-replace": "latest",
-    "grunt-ver": "git://github.com/oaeproject/grunt-ver.git#v0.2.3-hilary-0.2",
+    "grunt-ver": "git://github.com/CUL-DigitalServices/grunt-ver.git#v0.2.3-hilary-0.2",
     "optimist": "latest",
     "timetable-release-tools": "git://github.com/CUL-DigitalServices/timetable-release-tools"
   },


### PR DESCRIPTION
Currently the favicons are hashed and versioned which is causing 404's when you try to load them when using the production build. As hashing them results in no improvement, maybe they can simply be excluded?