### PR TITLE
Term dates seem incorrect

### DIFF
--- a/shared/gh/js/constants/gh.constants.js
+++ b/shared/gh/js/constants/gh.constants.js
@@ -51,6 +51,7 @@ define(['exports'], function(exports) {
         'admin-delete-series-modal': '/shared/gh/partials/tenant-admin/admin-delete-series-modal.html',
         'admin-edit-date-field': '/shared/gh/partials/tenant-admin/admin-edit-date-field.html',
         'admin-edit-dates': '/shared/gh/partials/tenant-admin/admin-edit-dates.html',
+        'admin-edit-dates-weeks': '/shared/gh/partials/tenant-admin/admin-edit-dates-weeks.html',
         'admin-editable-parts': '/shared/gh/partials/tenant-admin/admin-editable-parts.html',
         'admin-help': '/shared/gh/partials/tenant-admin/admin-help.html',
         'admin-login-form': '/shared/gh/partials/tenant-admin/admin-login-form.html',

--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -149,7 +149,7 @@ define(['gh.core', 'gh.constants', 'moment', 'clickover', 'gh.student.agenda-vie
     var changeTerm = function() {
         var termName = $(this).attr('data-term');
         // Retrieve the first day of term based on the name
-        var term = gh.utils.getFirstDayOfTerm(termName);
+        var term = gh.utils.getFirstLectureDayOfTerm(termName);
         // Navigate to a specific date in the calendar
         calendar.fullCalendar('gotoDate', term);
          // Set the current day
@@ -315,7 +315,7 @@ define(['gh.core', 'gh.constants', 'moment', 'clickover', 'gh.student.agenda-vie
         if (currentView === 'agendaWeek') {
 
             // Get the current academic week number
-            var weekNumber = gh.utils.getAcademicWeekNumber(getCurrentViewDate(), false);
+            var weekNumber = gh.utils.getAcademicWeekNumber(getCurrentViewDate());
 
             // Set the label
             label = 'Outside term week';

--- a/shared/gh/js/views/tenant-admin/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/tenant-admin/gh.admin-batch-edit-date.js
@@ -297,12 +297,12 @@ define(['gh.core', 'gh.api.config', 'lodash', 'moment', 'moment-timezone'], func
                             var eventDay = parseInt($('.gh-batch-edit-day-picker', $timePickerContainer).val(), 10);
                             // Get the date by week and day
                             // Since Cambridge weeks start on Thursdays, we should prevent that
-                            // chosen days are put after the current selected day. Therefore
-                            // we need to subtract one week for all the days except Tuesdays and
-                            // Wednesdays (We have a 2 day offset, since terms start on Tuesdays, sigh).
+                            // chosen days are put before the current selected day. Therefore
+                            // we need to add one week for all the days except Tuesdays and Wednesdays.
+                            // (We have a 2 day offset, since terms start on Tuesdays, sigh).
                             var dateByWeekAndDay = gh.utils.getDateByWeekAndDay(termName, eventWeek, eventDay);
-                            if (!_.contains([2,3], eventDay)) {
-                                dateByWeekAndDay = moment.tz(dateByWeekAndDay, 'Europe/London').subtract({'weeks': 1});
+                            if (_.contains([2,3], eventDay)) {
+                                dateByWeekAndDay = moment.tz(dateByWeekAndDay, 'Europe/London').add({'weeks': 1});
                             }
                             // Retrieve the year of the event
                             var eventYear = moment.tz(dateByWeekAndDay, 'Europe/London').format('YYYY');
@@ -352,16 +352,19 @@ define(['gh.core', 'gh.api.config', 'lodash', 'moment', 'moment-timezone'], func
                     _.defer(function() {
                         // Get the week number
                         var eventWeek = parseInt(chk.value, 10);
+
                         // Determine the day number, based on the academic week number
                         var eventDay = parseInt(moment.tz(new Date(), 'Europe/London').format('E'), 10);
+
                         // Get the date by week and day
                         var dateByWeekAndDay = gh.utils.getDateByWeekAndDay(termName, eventWeek, eventDay);
+
                         // Since Cambridge weeks start on Thursdays, we should prevent that
-                        // chosen days are put after the current selected day. Therefore
-                        // we need to subtract one week for all the days except Tuesdays and
-                        // Wednesdays (We have a 2 day offset, since terms start on Tuesdays, sigh).
-                        if (!_.contains([2,3], eventDay)) {
-                            dateByWeekAndDay = moment.tz(dateByWeekAndDay, 'Europe/London').subtract({'weeks': 1});
+                        // chosen days are put before the current selected day. Therefore
+                        // we need to add one week for the Tuesdays and Wednesdays
+                        // (We have a 2 day offset, since terms start on Tuesdays, sigh).
+                        if (_.contains([2,3], eventDay)) {
+                            dateByWeekAndDay = moment.tz(dateByWeekAndDay, 'Europe/London').add({'weeks': 1});
                         }
 
                         // Create the start date of the event

--- a/shared/gh/js/views/tenant-admin/gh.admin-batch-edit-date.js
+++ b/shared/gh/js/views/tenant-admin/gh.admin-batch-edit-date.js
@@ -130,7 +130,7 @@ define(['gh.core', 'gh.api.config', 'lodash', 'moment', 'moment-timezone'], func
                 // Get the start date of the event
                 var startDate = gh.utils.convertISODatetoUnixDate($row.find('.gh-event-date').attr('data-start'));
                 // Get the week in which the event takes place
-                var dateWeek = gh.utils.getAcademicWeekNumber(startDate, true);
+                var dateWeek = gh.utils.getAcademicWeekNumber(startDate);
                 // If the event takes place in the week that needs to be removed, delete it
                 if (dateWeek === weekNumber) {
                     $row.addClass('gh-event-deleted').find('.gh-event-delete button').click();
@@ -184,7 +184,7 @@ define(['gh.core', 'gh.api.config', 'lodash', 'moment', 'moment-timezone'], func
                     }
 
                     // Only add a new event for the generated day if the day is within a term
-                    var inTerm = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate(moment.tz(dateByWeekAndDay, 'Europe/London').format()), true);
+                    var inTerm = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate(moment.tz(dateByWeekAndDay, 'Europe/London').format()));
                     if (inTerm) {
 
                         var eventYear = moment.tz(dateByWeekAndDay, 'Europe/London').format('YYYY');
@@ -463,7 +463,7 @@ define(['gh.core', 'gh.api.config', 'lodash', 'moment', 'moment-timezone'], func
         // Extract the weeks from the batch
         _.each($rows, function(row) {
             var start = gh.utils.convertISODatetoUnixDate(moment.tz($(row).find('.gh-event-date').attr('data-start'), 'Europe/London').format('YYYY-MM-DD'));
-            weeksInUse.push(gh.utils.getAcademicWeekNumber(start, true));
+            weeksInUse.push(gh.utils.getAcademicWeekNumber(start));
         });
         return _.uniq(weeksInUse);
     };

--- a/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
@@ -159,10 +159,10 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
         } else {
             eventObj.data.ev = data && data.eventObj ? data.eventObj : {
                 'displayName': $('.gh-jeditable-series-title').text(),
-                'end': moment.tz([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 14, 0, 0, 0], 'Europe/London').format(),
+                'end': moment.tz(termStart, 'Europe/London').hours(14).format(),
                 'location': defaultLocation,
                 'organisers': defaultOrganisers,
-                'start': moment.tz([termStart.getFullYear(), termStart.getMonth(), termStart.getDate(), 13, 0, 0, 0], 'Europe/London').format(),
+                'start': moment.tz(termStart, 'Europe/London').hours(13).format(),
                 'type': gh.config.events.default
             };
         }

--- a/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
+++ b/shared/gh/js/views/tenant-admin/gh.admin-batch-edit.js
@@ -130,7 +130,7 @@ define(['gh.core', 'gh.constants', 'moment', 'moment-timezone', 'gh.calendar', '
     var addNewEventRow = function(ev, data) {
         var $eventContainer = data && data.eventContainer ? $(data.eventContainer) : $(this).closest('thead').next('tbody');
         var termName = $eventContainer.closest('.gh-batch-edit-events-container').data('term');
-        var termStart = gh.utils.getFirstDayOfTerm(termName);
+        var termStart = gh.utils.getFirstLectureDayOfTerm(termName);
         var eventObj = {
             'data': {
                 'ev': null

--- a/shared/gh/js/views/tenant-admin/gh.datepicker.js
+++ b/shared/gh/js/views/tenant-admin/gh.datepicker.js
@@ -215,7 +215,7 @@ define(['gh.core', 'moment', 'moment-timezone', 'clickover', 'jquery-datepicker'
 
         // Calculate the number of weeks in a term based on the date
         var numWeeks = 0;
-        var _term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate(moment.tz($(msg.trigger).attr('data-start'), 'Europe/London').format('YYYY-MM-DD')), true);
+        var _term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate(moment.tz($(msg.trigger).attr('data-start'), 'Europe/London').format('YYYY-MM-DD')));
         if (_term) {
             numWeeks = gh.utils.getWeeksInTerm(_term);
         }
@@ -320,7 +320,7 @@ define(['gh.core', 'moment', 'moment-timezone', 'clickover', 'jquery-datepicker'
         setDatePicker(calendarDate);
 
         // Set the week value
-        var week = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate(startDate), true);
+        var week = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate(startDate));
         $('.popover #gh-module-week').val(week);
 
         // Set the day value
@@ -398,7 +398,7 @@ define(['gh.core', 'moment', 'moment-timezone', 'clickover', 'jquery-datepicker'
             if (weekVal) {
 
                 // Retrieve the term
-                var term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate(moment.tz(dates.start, 'Europe/London').format('YYYY-MM-DD')), true);
+                var term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate(moment.tz(dates.start, 'Europe/London').format('YYYY-MM-DD')));
                 if (term) {
                     _term = term;
 
@@ -457,7 +457,7 @@ define(['gh.core', 'moment', 'moment-timezone', 'clickover', 'jquery-datepicker'
 
                 // Update the week
                 if ($(component).selector === '#gh-module-week') {
-                    var week = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate(moment.tz(dates.start, 'Europe/London').format('YYYY-MM-DD')), true);
+                    var week = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate(moment.tz(dates.start, 'Europe/London').format('YYYY-MM-DD')));
                     $(component).val(week);
 
                 // Update the day

--- a/shared/gh/partials/tenant-admin/admin-edit-dates-weeks.html
+++ b/shared/gh/partials/tenant-admin/admin-edit-dates-weeks.html
@@ -1,0 +1,11 @@
+<div class="form-group">
+    <label class="sr-only" for="gh-module-week">week</label>
+    <select id="gh-module-week" class="form-control" <% if (!data.numWeeks) { %>disabled<% } %>>
+        <% if (!data.numWeeks) { %><option value="0" disabled>Out of term</option><% } %>
+        <% if (data.numWeeks) { %>
+            <% for (var i = 1; i <= data.numWeeks; i++) { %>
+                <option value="<%- i %>">Week <%- i %></option>
+            <% } %>
+        <% } %>
+    </select>
+</div>

--- a/shared/gh/partials/tenant-admin/admin-edit-dates.html
+++ b/shared/gh/partials/tenant-admin/admin-edit-dates.html
@@ -2,17 +2,7 @@
     <form id="gh-edit-dates-form" role="form">
         <div class="col-xs-7 gh-col-datepicker" id="gh-datepicker"></div>
         <div class="col-xs-5 gh-col-time">
-            <div class="form-group">
-                <label class="sr-only" for="gh-module-week">week</label>
-                <select id="gh-module-week" class="form-control" <% if (!data.numWeeks) { %>disabled<% } %>>
-                    <option value="0" <% if (!data.numWeeks) { %>selected<% } %>>Out of term</option>
-                    <% if (data.numWeeks) { %>
-                        <% for (var i = 1; i <= data.numWeeks; i++) { %>
-                            <option value="<%- i %>">Week <%- i %></option>
-                        <% } %>
-                    <% } %>
-                </select>
-            </div>
+            <div id="gh-edit-dates-weeks"><!-- --></div>
             <div class="form-group">
                 <label class="sr-only" for="gh-module-day">day</label>
                 <select id="gh-module-day" class="form-control">

--- a/shared/gh/partials/tenant-student/student-agenda-view.html
+++ b/shared/gh/partials/tenant-student/student-agenda-view.html
@@ -20,7 +20,7 @@
      * @private
      */
     var getCurrentAcademicWeekNumber = function(moment) {
-        return data.utils.getAcademicWeekNumber(data.utils.convertISODatetoUnixDate((moment.tz(new Date(), 'Europe/London').format('YYYY-MM-DD'))), true);
+        return data.utils.getAcademicWeekNumber(data.utils.convertISODatetoUnixDate((moment.tz(new Date(), 'Europe/London').format('YYYY-MM-DD'))));
     };
 
     /**

--- a/tests/qunit/tests/js/api.util.js
+++ b/tests/qunit/tests/js/api.util.js
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, testAPI) {
+require(['gh.core', 'moment', 'gh.api.orgunit', 'gh.api.tests'], function(gh, moment, orgUnitAPI, testAPI) {
     module('Util API');
 
     // Mock a configuration object to test with
@@ -146,11 +146,11 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
         }, 'Verify that a valid end date needs to be provided');
 
         // Verify that all the cases are covered
-        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T17:30:00.000Z'), 'W6 · Wed 10am-5:30pm');
-        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T16:00:00.000Z', '2015-02-18T17:30:00.000Z'), 'W6 · Wed 4-5:30pm');
-        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T11:30:00.000Z'), 'W6 · Wed 10-11:30am');
-        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T11:00:00.000Z'), 'W6 · Wed 10:30-11am');
-        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T13:30:00.000Z'), 'W6 · Wed 10:30am-1:30pm');
+        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T17:30:00.000Z'), 'W5 · Wed 10am-5:30pm');
+        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T16:00:00.000Z', '2015-02-18T17:30:00.000Z'), 'W5 · Wed 4-5:30pm');
+        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T10:00:00.000Z', '2015-02-18T11:30:00.000Z'), 'W5 · Wed 10-11:30am');
+        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T11:00:00.000Z'), 'W5 · Wed 10:30-11am');
+        assert.strictEqual(gh.utils.generateDisplayDate('2015-02-18T10:30:00.000Z', '2015-02-18T13:30:00.000Z'), 'W5 · Wed 10:30am-1:30pm');
         assert.strictEqual(gh.utils.generateDisplayDate('2015-01-01T10:30:00.000Z', '2015-01-01T13:30:00.000Z'), 'OT · Thu 10:30am-1:30pm');
     });
 
@@ -168,24 +168,16 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
         }, 'Verify that a valid date needs to be provided');
 
         // Verify that no week number is returned when specifying an out-of-term date
-        var weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-01T10:30:00.000Z'));
+        var weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-01T12:30:00.000Z'));
         assert.strictEqual(weekNumber, 0, 'Verify that no week number is returned when specifying an out-of-term date');
-
-        // Verify that a valid week number is returned when specifying an out-of-term date that leans close to the start of a term
-        weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-12T10:30:00.000Z'));
-        assert.strictEqual(weekNumber, 1, 'Verify that a valid week number is returned when specifying an out-of-term date');
-
-        // Verify that a valid week number is returned when specifying an out-of-term date that leans close to the start of a term, using precise calculation
-        weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-12T10:30:00.000Z'), true);
-        assert.strictEqual(weekNumber, 0, 'Verify that a valid week number is returned when specifying an out-of-term date, using precise calculation');
 
         // Verify that a valid week number is returned when specifying an in-term date
         weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-14T10:30:00.000Z'));
-        assert.strictEqual(weekNumber, 1, 'Verify that a valid week number is returned when specifying an in-term date');
+        assert.strictEqual(weekNumber, 0, 'Verify that a valid week number is returned when specifying an in-term date');
 
         // Verify that a valid week number is returned when specifying an in-term date
         weekNumber = gh.utils.getAcademicWeekNumber(gh.utils.convertISODatetoUnixDate('2015-01-15T10:30:00.000Z'));
-        assert.strictEqual(weekNumber, 2, 'Verify that a valid week number is returned when specifying an in-term date');
+        assert.strictEqual(weekNumber, 1, 'Verify that a valid week number is returned when specifying an in-term date');
     });
 
     // Test the 'getTerm' functionality
@@ -201,21 +193,12 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
             gh.utils.getTerm('invalid_date');
         }, 'Verify that a valid date needs to be provided');
 
-        // Verify that a valid value for useOffset needs to be provided
-        assert.throws(function() {
-            gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2015-02-01T10:30:00.000Z'), 'invalid_value');
-        }, 'Verify that a valid value for useOffset needs to be provided');
-
         // Verify that the corresponding term is returned when specifying an in-term date
         var term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2015-02-01T10:30:00.000Z'));
         assert.strictEqual(term.name, 'lent', 'Verify that the corresponding term is returned');
 
-        // Verify that the corresponding term is returned when specifying an out-of-term date that leans close to the start of a term
-        term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2015-01-11T00:00:00.000Z'));
-        assert.strictEqual(term.name, 'lent', 'Verify that the corresponding term is returned');
-
         // Verify that no term is returned when specifying an out-of-term date that leans close to the start of a term
-        term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2015-01-11T00:00:00.000Z'), true);
+        term = gh.utils.getTerm(gh.utils.convertISODatetoUnixDate('2015-01-11T00:00:00.000Z'));
         assert.ok(!term);
 
         // Verify that no term is returned when specifying an out-of-term date
@@ -225,28 +208,30 @@ require(['gh.core', 'gh.api.orgunit', 'gh.api.tests'], function(gh, orgUnitAPI, 
 
     // Test the 'getWeeksInTerm' functionality
     QUnit.test('getWeeksInTerm', function(assert) {
-        // Get the first term of 2014 which has 9 weeks in it
         // Verify that a valid term needs to be provided
         assert.throws(function() {
             gh.utils.getWeeksInTerm();
         }, 'Verify that a valid term needs to be provided');
 
         // Verify that the correct number of weeks is returned
-        assert.strictEqual(gh.utils.getWeeksInTerm(require('gh.core').config.terms['2014'][0]), 10, 'Verify that the correct number of weeks is returned');
+        assert.strictEqual(gh.utils.getWeeksInTerm(require('gh.core').config.terms['2014'][0]), 8, 'Verify that the correct number of weeks is returned');
+        assert.strictEqual(gh.utils.getWeeksInTerm(require('gh.core').config.terms['2014'][1]), 8, 'Verify that the correct number of weeks is returned');
+        assert.strictEqual(gh.utils.getWeeksInTerm(require('gh.core').config.terms['2014'][2]), 7, 'Verify that the correct number of weeks is returned');
     });
 
-    // Test the 'getFirstDayOfTerm' functionality
-    QUnit.test('getFirstDayOfTerm', function(assert) {
+    // Test the 'getFirstLectureDayOfTerm' functionality
+    QUnit.test('getFirstLectureDayOfTerm', function(assert) {
         // Verify that a valid term name needs to be provided
         assert.throws(function() {
-            gh.utils.getFirstDayOfTerm(null);
+            gh.utils.getFirstLectureDayOfTerm(null);
         }, 'Verify that a valid term name needs to be provided');
 
         // Use the first day of Michaelmas to test with
-        var testDate = new Date('2014-10-07T00:00:00.000Z');
-        assert.strictEqual(gh.utils.getFirstDayOfTerm('michaelmas').getDay(), testDate.getDay(), 'Verify that the correct day is returned');
-        assert.strictEqual(gh.utils.getFirstDayOfTerm('michaelmas').getMonth(), testDate.getMonth(), 'Verify that the correct month is returned');
-        assert.strictEqual(gh.utils.getFirstDayOfTerm('michaelmas').getFullYear(), testDate.getFullYear(), 'Verify that the correct year is returned');
+        var testDate = moment('2014-10-09T00:00:00.000Z');
+        var firstLectureDay = gh.utils.getFirstLectureDayOfTerm('michaelmas');
+        assert.strictEqual(moment.utc(firstLectureDay).format('DD'), moment.utc(testDate).format('DD'), 'Verify that the correct day is returned');
+        assert.strictEqual(moment.utc(firstLectureDay).format('MM'), moment.utc(testDate).format('MM'), 'Verify that the correct month is returned');
+        assert.strictEqual(moment.utc(firstLectureDay).format('YYYY'), moment.utc(testDate).format('YYYY'), 'Verify that the correct year is returned');
     });
 
     // Test the 'getDateByWeekAndDay' functionality


### PR DESCRIPTION
I created an app for `2014` whose easter term [starts on 21st April](https://www.cam.ac.uk/about-the-university/term-dates-and-calendars). As far as I can work out, this means that week 1 runs from the 23rd till the 29th. However, the UI displays the week before that:
![](https://cldup.com/Tt-uGRTKSM-1200x1200.png)