### PR TITLE
Event type select box needs some left margin

### DIFF
--- a/apps/timetable/admin/ui/css/admin.css
+++ b/apps/timetable/admin/ui/css/admin.css
@@ -836,6 +836,10 @@ ul.gh-borrowed-list li p {
     padding: 6px 0 6px 15px;
 }
 
+#gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-event-type {
+    padding-right: 6px;
+}
+
 #gh-batch-edit-container h1.gh-disabled,
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > thead > tr.gh-disabled > th,
 #gh-batch-edit-term-container .gh-batch-edit-events-container .table > tbody > tr > td.gh-disabled {


### PR DESCRIPTION
OSX 10.10 - Chrome v43

![screen shot 2015-05-21 at 17 15 22](https://cloud.githubusercontent.com/assets/2194396/7753390/0419a6a0-ffdd-11e4-83db-6e3789ca9414.png)
