### PR TITLE
Missing feedback when a part has no modules when borrowing

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -1247,7 +1247,8 @@ tbody tr:last-child > td.fc-widget-content {
     margin: 15px 0 12px;
 }
 
-.agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week  .gh-agenda-view-no-events {
+#gh-borrow-series-modal .gh-admin-borrow-series-no-modules,
+.agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week .gh-agenda-view-no-events {
     padding: 20px;
     text-align: center;
 }

--- a/shared/gh/css/gh.skin.css
+++ b/shared/gh/css/gh.skin.css
@@ -764,6 +764,7 @@ tbody .fc-sun {
     color: #919191;
 }
 
+#gh-borrow-series-modal .gh-admin-borrow-series-no-modules,
 .agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week  .gh-agenda-view-no-events {
     background-color: #F5F5F5;
     color: #999;
@@ -835,6 +836,7 @@ span.gh-agenda-view-middot {
     border-top-color: #DDD;
 }
 
+#gh-borrow-series-modal .gh-admin-borrow-series-no-modules,
 #gh-series-info-modal .gh-series-info-list-no-events,
 #gh-series-info-modal .gh-series-info-location,
 #gh-series-info-modal .gh-series-info-organiser {

--- a/shared/gh/partials/tenant-admin/admin-borrow-series-module-item.html
+++ b/shared/gh/partials/tenant-admin/admin-borrow-series-module-item.html
@@ -2,6 +2,10 @@
 
 <% var records = (!isChild) ? data.modules : data; %>
 
+<% if (!records.length) { %>
+    <div class="gh-admin-borrow-series-no-modules">This part does not have any modules and event series that can be borrowed.</div>
+<% } %>
+
 <% _.each(records, function(d) { %>
     <li class="list-group-item <% if (d.expanded) { %>gh-list-group-item-open<% } %>" data-id="<%- d.id %>">
         <div class="gh-list-group-item-container">


### PR DESCRIPTION
Some feedback should be displayed when a part without modules was selected in the borrowing modal.

![xhikpesntp-3000x3000](https://cloud.githubusercontent.com/assets/2194396/7815223/064f2144-03bf-11e5-96bc-d3200df4e739.png)
