### PR TITLE
Calendar view options should be re-ordered

### DIFF
--- a/shared/gh/js/views/gh.subheader.js
+++ b/shared/gh/js/views/gh.subheader.js
@@ -180,7 +180,7 @@ define(['gh.core', 'gh.constants', 'gh.api.orgunit', 'gh.admin.visibility', 'cho
             }).change(setUpPartPicker);
 
             // Set the default placeholder text
-            $('#gh_subheader_tripos_chosen .chosen-search input').attr('placeholder', 'Search triposes');
+            $('#gh_subheader_tripos_chosen .chosen-search input').attr('placeholder', 'Search courses');
         });
     };
 

--- a/shared/gh/partials/calendar.html
+++ b/shared/gh/partials/calendar.html
@@ -73,13 +73,13 @@
                         </button>
                         <ul class="dropdown-menu pull-right" role="menu" aria-labelledby="gh-switch-view-container">
                             <li role="presentation">
+                                <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="agendaDay" role="menuitem">Day view</button>
+                            </li>
+                            <li role="presentation">
                                 <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="agendaWeek" role="menuitem">Week view</button>
                             </li>
                             <li role="presentation">
                                 <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="month" role="menuitem">Month view</button>
-                            </li>
-                            <li role="presentation">
-                                <button type="button" class="btn btn-default gh-btn-secondary gh-switch-view" data-view="agendaDay" role="menuitem">Day view</button>
                             </li>
                         </ul>
                     </li>


### PR DESCRIPTION
The options in the calendar view dropdown should be re-arranged to have an ascending or descending magnitude of time (either Day > Week > Month or Month > Week > Day)

![screen shot 2015-05-27 at 23 46 36](https://cloud.githubusercontent.com/assets/109850/7854084/cd19a43c-04ca-11e5-9bb1-b9df24ecabb9.png)
