### PR TITLE
Raven sign in button is not vertically centered

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -29,7 +29,7 @@
 
 #gh-right-container #gh-header .gh-signin-form,
 #gh-right-container #gh-header #gh-signout-form {
-    margin: 42px 30px 35px 40px;
+    margin: 38px 30px 38px 40px;
 }
 
 


### PR DESCRIPTION
The Raven sign in button is not vertically centered inside of the white bar it's in:

![screen shot 2015-05-27 at 23 37 32](https://cloud.githubusercontent.com/assets/109850/7854055/8c3f8760-04ca-11e5-9c9a-a8f0e3a469ce.png)
