### PR TITLE
"Search triposes" field does not align with placeholder

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -567,7 +567,6 @@ tbody tr:last-child > td.fc-widget-content {
 }
 
 #gh-empty-access {
-    margin-bottom: 30px;
     margin-top: 30px;
     padding: 20px 25px;
 }


### PR DESCRIPTION
The cursor in the "Search triposes" field does not appear to be perfectly aligned with the placeholder text in the field. 

![screen shot 2015-05-27 at 23 48 36](https://cloud.githubusercontent.com/assets/109850/7854124/2bb802ea-04cb-11e5-82d0-59eeb0102834.png)
