### PR TITLE
Spacing around "Unfortunately this is not in Timetable yet"

### DIFF
--- a/shared/gh/css/gh.components.css
+++ b/shared/gh/css/gh.components.css
@@ -567,7 +567,6 @@ tbody tr:last-child > td.fc-widget-content {
 }
 
 #gh-empty-access {
-    margin-bottom: 30px;
     margin-top: 30px;
     padding: 20px 25px;
 }


### PR DESCRIPTION
The "Unfortunately this is not in Timetable yet" message has more spacing above it than below it, causing the visual balance of the page to be slightly off:

![screen shot 2015-05-27 at 23 52 33](https://cloud.githubusercontent.com/assets/109850/7854163/954aa064-04cb-11e5-9af9-bed902546f50.png)
