### PR TITLE
Footer overlaps with page content when collapsing sidebar

### DIFF
--- a/shared/gh/css/gh.base.css
+++ b/shared/gh/css/gh.base.css
@@ -227,7 +227,7 @@ footer ul li {
 
 #gh-page-container #gh-left-container #gh-navigation-container,
 #gh-page-container #gh-left-container #gh-modules-container {
-    min-height: calc(100% - 217px);
+    min-height: 100%;
     padding-top: 215px;
 }
 


### PR DESCRIPTION
The footer overlaps with the page content when collapsing the sidebar.
This was tested on FF 38.0.1

![screen shot 2015-05-27 at 23 36 24](https://cloud.githubusercontent.com/assets/109850/7854046/6b428710-04ca-11e5-838e-c77ae874d2f8.png)
