### PR TITLE
Timezone issue in batch edit date picker

### DIFF
--- a/shared/gh/js/utils/gh.utils.time.js
+++ b/shared/gh/js/utils/gh.utils.time.js
@@ -247,7 +247,7 @@ define(['exports', 'gh.constants', 'moment', 'moment-timezone'], function(export
         });
 
         // Return the date of the first lecture day
-        return moment(term.start).add({'days': 2, 'hours': 1}).toISOString();
+        return moment(term.start).add({'days': 2, 'hours': -((new Date()).getTimezoneOffset() / 60)}).toISOString();
     };
 
     /**

--- a/shared/gh/js/views/gh.calendar.js
+++ b/shared/gh/js/views/gh.calendar.js
@@ -149,9 +149,9 @@ define(['gh.core', 'gh.constants', 'moment', 'clickover', 'gh.student.agenda-vie
     var changeTerm = function() {
         var termName = $(this).attr('data-term');
         // Retrieve the first day of term based on the name
-        var term = gh.utils.getFirstLectureDayOfTerm(termName);
+        var firstLectureDay = gh.utils.getFirstLectureDayOfTerm(termName);
         // Navigate to a specific date in the calendar
-        calendar.fullCalendar('gotoDate', term);
+        calendar.fullCalendar('gotoDate', firstLectureDay);
          // Set the current day
         setCurrentDay();
         // Set the week label

--- a/shared/gh/js/views/tenant-admin/gh.datepicker.js
+++ b/shared/gh/js/views/tenant-admin/gh.datepicker.js
@@ -435,9 +435,8 @@ define(['gh.core', 'moment', 'moment-timezone', 'clickover', 'jquery-datepicker'
 
         // Recalculate the date based on the selected day
         } else if (trigger === '#gh-module-day') {
-
             // Retrieve the current day
-            var currentDay = moment.tz(dates.start, 'Europe/London').format('E');
+            var currentDay = parseInt(moment.tz(moment(dates.start).add({'hours': 1}), 'Europe/London').format('E'), 10);
 
             // Calculate the start of the week
             var dayOffset = -3;
@@ -446,7 +445,7 @@ define(['gh.core', 'moment', 'moment-timezone', 'clickover', 'jquery-datepicker'
             }
             dayOffset = currentDay - dayOffset;
 
-            var weekStart = moment.tz(dates.start, 'Europe/London').add({'hours': 1}).subtract({'days': dayOffset}).format('YYYY-MM-DD');
+            var weekStart = moment.tz(moment(dates.start).add({'hours': 1}), 'Europe/London').subtract({'days': dayOffset}).format('YYYY-MM-DD');
 
             // Retrieve the selected day value
             var dayVal = parseInt($('#gh-module-day option:selected').attr('data-day'), 10);
@@ -479,7 +478,7 @@ define(['gh.core', 'moment', 'moment-timezone', 'clickover', 'jquery-datepicker'
 
                 // Update the day
                 } else if ($(component).selector === '#gh-module-day') {
-                    var day = moment.tz(dates.start, 'Europe/London').day();
+                    var day = moment.tz(moment(dates.start).add({'hours': 1}), 'Europe/London').day();
                     $(component).val(day);
                 }
             }

--- a/shared/gh/js/views/tenant-admin/gh.datepicker.js
+++ b/shared/gh/js/views/tenant-admin/gh.datepicker.js
@@ -103,8 +103,9 @@ define(['gh.core', 'moment', 'moment-timezone', 'clickover', 'jquery-datepicker'
         var entries = getFormValues();
 
         // Generate the start and end dates
-        var startDate = moment.tz(entries.date, 'Europe/London').hour(entries.startHour).minute(entries.startMinutes).toISOString();
-        var endDate = moment.tz(entries.date, 'Europe/London').hour(entries.endHour).minute(entries.endMinutes).toISOString();
+        // The selected date will be in local time, keep in mind the offset when adding hours to match the correct date
+        var startDate = moment.tz(moment(entries.date).add({'hours': -((new Date()).getTimezoneOffset() / 60)}), 'Europe/London').hour(entries.startHour).minute(entries.startMinutes).toISOString();
+        var endDate = moment.tz(moment(entries.date).add({'hours': -((new Date()).getTimezoneOffset() / 60)}), 'Europe/London').hour(entries.endHour).minute(entries.endMinutes).toISOString();
 
         // Return the full dates
         return {


### PR DESCRIPTION
The batch edit datepicker seems confused when in the `Europe/Paris` timezone. Selecting a Thursday in the calendar auto-selects a Wednesday in the select field and that's the one that's applied when saving changes.

![screen shot 2015-06-01 at 14 51 35](https://cloud.githubusercontent.com/assets/218391/7913155/5c6b3d6a-0865-11e5-910d-929b4f2242d3.png)
