### PR TITLE
'My agenda' print view refinements

### DIFF
--- a/shared/gh/scss/gh.print.scss
+++ b/shared/gh/scss/gh.print.scss
@@ -16,6 +16,7 @@
 @media print {
 
     body {
+        width: 100%;
         height: 0 !important;
     }
 
@@ -95,7 +96,23 @@
         display: none;
     }
 
-    .gh-event-type:not(:empty)::before {
+    .agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week .gh-agenda-view-term-event .gh-agenda-view-event-information .gh-event-type-container {
+        float: left !important;
+        font-weight: 600;
+        margin: 0;
+        padding-right: 5px;
+    }
+
+    .agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week .gh-agenda-view-term-event .gh-agenda-view-event-information .gh-event-type-container {
+        margin-top: 0;
+        width: inherit;
+    }
+
+    .agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week .gh-agenda-view-term-event .gh-agenda-view-event-information .gh-event-type-container:after {
+        content: '·';
+    }
+
+    .agenda-view-term .agenda-view-term-events .gh-agenda-view-term-week .gh-agenda-view-term-event .gh-agenda-view-event-information .gh-event-type:not(:empty)::before {
         display: none;
     }
 

--- a/shared/gh/scss/gh.print.scss
+++ b/shared/gh/scss/gh.print.scss
@@ -94,4 +94,13 @@
     #gh-my-agenda-view .gh-btn-load-next-week {
         display: none;
     }
+
+    .gh-event-type:not(:empty)::before {
+        display: none;
+    }
+
+    /* Calendar today icon */
+    .gh-agenda-view-today .gh-event-calendar-icon {
+        border-color: #888;
+    }
 }


### PR DESCRIPTION
Refine the `My agenda` print view:

- [x] Hide the event type abbreviation from print view
- [x] Don't highlight the current day in print view