### PR TITLE
Don't disable cache for GET requests in tests

### DIFF
--- a/shared/gh/js/controllers/gh.api.tests.js
+++ b/shared/gh/js/controllers/gh.api.tests.js
@@ -281,6 +281,12 @@ define(['exports', 'gh.utils', 'gh.api.app', 'gh.api.authentication', 'gh.api.or
     var onTestStart = function(details) {
         QUnit.stop();
 
+        // Enable cache for GET requests as Sinon relies on a known URL in order to be able
+        // to intercept the call
+        $.ajaxSetup({
+            'cache': true
+        });
+
         // Reset the test data
         _apps = null;
         _tenants = null;


### PR DESCRIPTION
Sinon relies on knowing the URL it'll need to intercept, including parameters. If we disable cache the qunit tests will fail every time Sinon is used as it won't know the random value attached to the request to bust its cache.