### PR TITLE
Overflow on left container should be adjusted

### DIFF
--- a/shared/gh/js/views/gh.listview.js
+++ b/shared/gh/js/views/gh.listview.js
@@ -184,6 +184,7 @@ define(['gh.utils', 'gh.api.orgunit', 'gh.constants'], function(utils, orgunitAP
 
         // If the modules are toggled, set the display of the module list to none
         if ($('html').hasClass('gh-collapsed')) {
+            $('#gh-left-container').addClass('gh-collapsed');
             setTimeout(function() {
                 // Hide the modules list after the animations complete
                 $('#gh-modules-list').css('display', 'none');
@@ -195,11 +196,12 @@ define(['gh.utils', 'gh.api.orgunit', 'gh.constants'], function(utils, orgunitAP
                 utils.trackEvent(['Navigation', 'Collapsed']);
             }, 300);
         } else {
-            // Show the modules list before the animation starts
-            $('#gh-modules-list').css('display', 'block');
             // Toggle the animation finished class
             $('html').toggleClass('gh-collapsed-finished');
+            // Show the modules list before the animation starts
+            $('#gh-modules-list').css('display', 'block');
             setTimeout(function() {
+                $('#gh-left-container').removeClass('gh-collapsed');
                 // Trigger a window resize event to let all components adjust themselves
                 $(window).trigger('resize');
                 // Send a tracking event

--- a/shared/gh/scss/gh.base.scss
+++ b/shared/gh/scss/gh.base.scss
@@ -156,7 +156,7 @@ footer,
 
 #gh-page-container #gh-left-container {
     float: left;
-    overflow: hidden;
+    overflow: visible;
     padding: 0;
     position: relative;
     -webkit-transition: width .3s;
@@ -167,9 +167,13 @@ footer,
     z-index: 3;
 }
 
+#gh-page-container.gh-minimised #gh-left-container,
+#gh-page-container #gh-left-container.gh-collapsed {
+    overflow: hidden !important;
+}
+
 #gh-page-container.gh-minimised #gh-left-container {
     height: 215px;
-    overflow: hidden;
 }
 
 footer .gh-uni-logo,
@@ -258,7 +262,7 @@ footer ul li {
 }
 
 #gh-page-container #gh-left-container #gh-modules-container #gh-result-summary button:not(.gh-collapse-modules),
-#gh-page-container #gh-page-container #gh-left-container #gh-modules-list-container ul {
+#gh-page-container #gh-left-container #gh-modules-list-container ul {
     -webkit-transition: opacity .3s;
        -moz-transition: opacity .3s;
          -o-transition: opacity .3s;


### PR DESCRIPTION
The left hand navigation needs to have `overflow: hidden` applied to it when it animates. When it's not animating and not collapsed that property shouldn't be applied to allow the module settings to drop open outside of the container.

![screen shot 2015-06-04 at 03 48 30](https://cloud.githubusercontent.com/assets/218391/7964630/db4cb4fc-0a6c-11e5-8c95-27a9dc2e9330.png)
