### PR TITLE
Explain why a user can't be created

### DIFF
--- a/shared/gh/partials/global-admin/app-user.html
+++ b/shared/gh/partials/global-admin/app-user.html
@@ -68,4 +68,8 @@
             </div>
         </form>
     </div>
+<% } else {%>
+    <div class="gh-striped-row row text-center">
+        <p>Local account creation has not been enabled for this application</p>
+    </div>
 <% } %>

--- a/shared/gh/partials/global-admin/app-user.html
+++ b/shared/gh/partials/global-admin/app-user.html
@@ -68,7 +68,7 @@
             </div>
         </form>
     </div>
-<% } else {%>
+<% } else { %>
     <div class="gh-striped-row row text-center">
         <p>Local account creation has not been enabled for this application</p>
     </div>


### PR DESCRIPTION
Add a message to the global admin UI user list when local authentication hasn't been enabled to make sure admins know why the form isn't there.