### PR TITLE
Add z-index so users autosuggest is over footer

### DIFF
--- a/apps/timetable/admin/app/scss/tenant.admin.components.scss
+++ b/apps/timetable/admin/app/scss/tenant.admin.components.scss
@@ -26,6 +26,10 @@ main {
     width: 300px;
 }
 
+.as-results .as-list {
+    z-index: 10;
+}
+
 #gh-app-user-container #gh-user-permissions-form,
 #gh-app-user-container {
     margin: 25px 0 !important;


### PR DESCRIPTION
There is a bigger issue here as the footer doesn't display at the bottom of the page in IE, but this will at least display the user list over it on small windows.